### PR TITLE
bug fix showing no records if navigating to recent matches from home page

### DIFF
--- a/components/player-card/player-recent-matches.tsx
+++ b/components/player-card/player-recent-matches.tsx
@@ -38,7 +38,7 @@ const PlayerRecentMatches = ({
     );
     setSortedData(sortStatus.direction === "desc" ? resortedData.reverse() : resortedData);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortStatus]);
+  }, [sortStatus, playerMatchesData]);
 
   if (error) {
     return <ErrorCard title={"Error rendering recent matches"} body={JSON.stringify(error)} />;


### PR DESCRIPTION
added `playerMatchesData` to `useEffect` dependency array. Was showing `No records` in recent matches tab if clicking to there the first time from the home page.