### PR TITLE
Fix replace signature url with content of signature file

### DIFF
--- a/pages/api/appUpdateRoute.ts
+++ b/pages/api/appUpdateRoute.ts
@@ -41,15 +41,24 @@ export default async function handler(req: any, res: any) {
     });
   }
 
-  res.status(200).json({
-    version: "v" + response.data.tag_name,
-    notes: response.data.body,
-    pub_date: date.toISOString(),
-    platforms: {
-      "windows-x86_64": {
-        signature: sigURL,
-        url: zipURL,
+  try {
+    const fileResponse = await fetch(sigURL);
+    const fileContent = await fileResponse.text();
+
+    return res.status(200).json({
+      version: "v" + response.data.tag_name,
+      notes: response.data.body,
+      pub_date: date.toISOString(),
+      platforms: {
+        "windows-x86_64": {
+          signature: fileContent,
+          url: zipURL,
+        },
       },
-    },
-  });
+    });
+  } catch (error) {
+    return res.status(500).json({
+      message: "Could not retrieve contends of the signature file.",
+    });
+  }
 }


### PR DESCRIPTION
Had to fix the updater api route. It returned the link to the signature file but instead should return the content of the signature file