### PR TITLE
Add next js types to api handlers and fix all resulting type errors

### DIFF
--- a/pages/api/appUpdateRoute.ts
+++ b/pages/api/appUpdateRoute.ts
@@ -2,9 +2,10 @@
  * This route is used be the desktop app to determine if the auto updater should update the app
  */
 
+import { NextApiRequest, NextApiResponse } from "next";
 import { Octokit } from "octokit";
 
-export default async function handler(req: any, res: any) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const octokit = new Octokit();
   const response = await octokit.request("GET /repos/{owner}/{repo}/releases/latest", {
     owner: "cohstats",

--- a/pages/api/onlineSteamPlayers.ts
+++ b/pages/api/onlineSteamPlayers.ts
@@ -5,8 +5,9 @@
 
 import { getNumberOfOnlinePlayersSteamUrl } from "../../src/steam-api";
 import { logger } from "../../src/logger";
+import { NextApiRequest, NextApiResponse } from "next";
 
-export default async function handler(req: any, res: any) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const fetchResponse = await fetch(getNumberOfOnlinePlayersSteamUrl());
     const { response } = await fetchResponse.json();
@@ -17,6 +18,6 @@ export default async function handler(req: any, res: any) {
       .json({ playerCount: response.player_count, timeStampMs: new Date().valueOf() });
   } catch (e) {
     logger.error(e);
-    res.status(500).json();
+    res.status(500).json({});
   }
 }

--- a/pages/leaderboards.tsx
+++ b/pages/leaderboards.tsx
@@ -14,6 +14,7 @@ import Head from "next/head";
 import { localizedGameTypes, localizedNames } from "../src/coh3/coh3-data";
 import { raceType, leaderBoardType } from "../src/coh3/coh3-types";
 import FactionIcon from "../components/faction-icon";
+import { GetServerSideProps } from "next";
 
 /**
  * Timeago is causing issues with SSR, move to clinet side
@@ -229,13 +230,20 @@ const sortById = {
   elo: 1,
 };
 
-export async function getServerSideProps({ query }: any) {
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   const { race, type, sortBy, start } = query;
 
-  const raceToFetch = race || "american";
-  const typeToFetch = type || "1v1";
+  const raceToFetch = (race as raceType) || "american";
+  const typeToFetch = (type as leaderBoardType) || "1v1";
   const sortByToFetch = sortById[sortBy as "wins" | "elo"] || 1;
-  const startToFetch = start || 1;
+  let startNumber: number | undefined;
+  if (start) {
+    const number = Number(start);
+    if (!isNaN(number)) {
+      startNumber = number;
+    }
+  }
+  const startToFetch = startNumber || 1;
 
   let leaderBoardData = null;
   let error = null;
@@ -267,6 +275,6 @@ export async function getServerSideProps({ query }: any) {
       typeToFetch,
     }, // will be passed to the page component as props
   };
-}
+};
 
 export default Leaderboards;

--- a/pages/players/[playerID].tsx
+++ b/pages/players/[playerID].tsx
@@ -20,6 +20,7 @@ import Head from "next/head";
 import React from "react";
 import { PlayerCardDataType } from "../../src/coh3/coh3-types";
 import { getPlayerCardInfoUrl } from "../../src/coh3stats-api";
+import { GetServerSideProps } from "next";
 
 /**
  *
@@ -142,9 +143,12 @@ const PlayerCard = ({
 // THIS code is super dirty to get the things done, needs to be fixed
 // I am not sure if it's a good idea to have it as query parameter
 // I am counting with the old url setup as we had on coh2stats https://coh2stats.com/players/76561198051168720-F3riG?view=recentMatches
-// @ts-ignore
-export async function getServerSideProps({ params, query }) {
-  const { playerID } = params;
+export const getServerSideProps: GetServerSideProps<any, { playerID: string }> = async ({
+  params,
+  query,
+  res,
+}) => {
+  const { playerID } = params!;
   const { view } = query;
 
   let playerData = null;
@@ -198,6 +202,6 @@ export async function getServerSideProps({ params, query }) {
   return {
     props: { playerID, playerData, error, playerMatchesData }, // will be passed to the page component as props
   };
-}
+};
 
 export default PlayerCard;

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,3 +1,4 @@
+import { GetServerSideProps, NextPage } from "next";
 import config from "../config";
 
 /**
@@ -11,8 +12,7 @@ import config from "../config";
  * @constructor
  */
 
-// @ts-ignore
-function Search({ searchQuery, data, error }) {
+const Search: NextPage<any> = ({ searchQuery, data, error }) => {
   // Render data...
 
   return (
@@ -22,10 +22,9 @@ function Search({ searchQuery, data, error }) {
       <div>error {JSON.stringify(error)}</div>
     </>
   );
-}
+};
 
-// @ts-ignore
-export async function getServerSideProps({ query }) {
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   const { q } = query;
 
   console.log("SEARCH", q);
@@ -49,6 +48,6 @@ export async function getServerSideProps({ query }) {
   return {
     props: { searchQuery: q, data, error }, // will be passed to the page component as props
   };
-}
+};
 
 export default Search;


### PR DESCRIPTION
I am adding all missing types for the nextjs handlers to enable typescript to show potential errors due to incorrect usage.

Starting with api routes. Added the types for the handlers request and response and fixed all warnings that occured.
