### PR TITLE
General improvements after 1.1.0

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -166,7 +166,7 @@ export const Header: React.FC<HeaderProps> = () => {
               Desktop App
             </Anchor>
 
-            <ExplorerMenu cx={cx} classes={classes} />
+            <ExplorerMenu cx={cx} close={close} classes={classes} />
 
             <Anchor
               component={Link}
@@ -245,7 +245,7 @@ export const Header: React.FC<HeaderProps> = () => {
               Desktop App
             </Anchor>
 
-            <ExplorerMenu cx={cx} classes={classes} />
+            <ExplorerMenu cx={cx} close={close} classes={classes} />
 
             <Anchor component={Link} href={getAboutRoute()} className={cx(classes.link)}>
               About

--- a/components/Header/components/ExplorerMenu.tsx
+++ b/components/Header/components/ExplorerMenu.tsx
@@ -17,11 +17,16 @@ import FactionIcon from "../../faction-icon";
 import { getDPSCalculatorRoute, getExplorerFactionRoute } from "../../../src/routes";
 import { localizedNames } from "../../../src/coh3/coh3-data";
 
-const explorerFactionLink = (faction: raceType) => {
+const explorerFactionLink = (faction: raceType, close: () => void) => {
   return (
     <Flex direction="row" align="center" gap="md">
       <FactionIcon name={faction} width={24} />
-      <Anchor color="orange" component={Link} href={getExplorerFactionRoute(faction)}>
+      <Anchor
+        color="orange"
+        component={Link}
+        href={getExplorerFactionRoute(faction)}
+        onClick={close}
+      >
         {localizedNames[faction]}
       </Anchor>
     </Flex>
@@ -32,9 +37,9 @@ const explorerFactionLink = (faction: raceType) => {
  * @TODO Provide the toolName type for the routes. In the meantime, provide the
  * route fragment as string.
  */
-const explorerToolLink = (toolName: string) => (
+const explorerToolLink = (toolName: string, close: () => void) => (
   <Text>
-    <Anchor color="orange" component={Link} href={getDPSCalculatorRoute()}>
+    <Anchor color="orange" component={Link} href={getDPSCalculatorRoute()} onClick={close}>
       {toolName}
     </Anchor>
   </Text>
@@ -43,9 +48,11 @@ const explorerToolLink = (toolName: string) => (
 const ExplorerMenu = ({
   cx,
   classes,
+  close,
 }: {
   cx: (...args: any) => string;
   classes: Record<string, string>;
+  close: () => void;
 }) => {
   const mobileView = (
     <Group className={classes.hiddenDesktop} grow>
@@ -56,15 +63,15 @@ const ExplorerMenu = ({
           </Accordion.Control>
           <Accordion.Panel>
             <Stack>
-              {explorerFactionLink("german")}
-              {explorerFactionLink("american")}
-              {explorerFactionLink("dak")}
-              {explorerFactionLink("british")}
+              {explorerFactionLink("german", close)}
+              {explorerFactionLink("american", close)}
+              {explorerFactionLink("dak", close)}
+              {explorerFactionLink("british", close)}
             </Stack>
             <Divider my="sm"></Divider>
             <Stack>
               <Text weight={700}>Tools</Text>
-              {explorerToolLink("DPS - Unit Comparison")}
+              {explorerToolLink("DPS - Unit Comparison", close)}
             </Stack>
           </Accordion.Panel>
         </Accordion.Item>
@@ -87,16 +94,16 @@ const ExplorerMenu = ({
           <Grid gutter={0} columns={2}>
             <Grid.Col span={1}>
               <Stack>
-                {explorerFactionLink("german")}
-                {explorerFactionLink("american")}
-                {explorerFactionLink("dak")}
-                {explorerFactionLink("british")}
+                {explorerFactionLink("german", () => null)}
+                {explorerFactionLink("american", () => null)}
+                {explorerFactionLink("dak", () => null)}
+                {explorerFactionLink("british", () => null)}
               </Stack>
             </Grid.Col>
             <Grid.Col span={1}>
               <Stack>
                 <Text weight={700}>Tools</Text>
-                {explorerToolLink("DPS - Unit Comparison")}
+                {explorerToolLink("DPS - Unit Comparison", () => null)}
               </Stack>
             </Grid.Col>
           </Grid>

--- a/components/unit-cards/battlegroup-card.tsx
+++ b/components/unit-cards/battlegroup-card.tsx
@@ -75,48 +75,6 @@ const BattlegroupBranchMapping = (branch: BattlegroupResolvedBranchType) => {
   );
 };
 
-/** Battlegroup icons are not 1:1 and the current ones make use of re-used assets. */
-const BattlegroupIcons = {
-  dak: {
-    armored_support: "races/afrika_corps/battlegroups/armored_ak_ger_portrait",
-    italian_combined_arms: "races/afrika_corps/battlegroups/combined_arms_ak_portrait",
-    italian_infantry: "races/afrika_corps/battlegroups/italian_infantry_ak_portrait",
-  } as Record<BattlegroupAfricaKorpsIds, string>,
-  german: {
-    breakthrough: "races/german/battlegroups/breakthrough_ger_portrait",
-    luftwaffe: "races/german/battlegroups/luftwaffe_ger_portrait",
-    mechanized: "races/german/battlegroups/mechanized_ger_ger_portrait",
-  } as Record<BattlegroupGermanIds, string>,
-  american: {
-    airborne: "races/american/battlegroups/paratroopers_us_portrait",
-    armored: "races/american/battlegroups/armored_us_portrait",
-    special_operations: "races/american/battlegroups/spec_ops_us_portrait",
-  } as Record<BattlegroupAmericanIds, string>,
-  british: {
-    british_air_and_sea: "races/british/battlegroups/air_and_sea_uk_portrait",
-    british_armored: "races/british/battlegroups/armored_uk_portrait",
-    indian_artillery: "races/british/battlegroups/indian_artillery_uk_portrait",
-  } as Record<BattlegroupBritishIds, string>,
-} as const;
-
-type BattlegroupAfricaKorpsIds = "armored_support" | "italian_combined_arms" | "italian_infantry";
-type BattlegroupGermanIds = "breakthrough" | "luftwaffe" | "mechanized";
-type BattlegroupBritishIds = "british_air_and_sea" | "british_armored" | "indian_artillery";
-type BattlegroupAmericanIds = "airborne" | "armored" | "special_operations";
-
-function getBattlegroupIcon(id: string, race: raceType) {
-  switch (race) {
-    case "dak":
-      return BattlegroupIcons.dak[id as BattlegroupAfricaKorpsIds];
-    case "german":
-      return BattlegroupIcons.german[id as BattlegroupGermanIds];
-    case "american":
-      return BattlegroupIcons.american[id as BattlegroupAmericanIds];
-    case "british":
-      return BattlegroupIcons.british[id as BattlegroupBritishIds];
-  }
-}
-
 export const BattlegroupCard = (
   race: raceType,
   data: {
@@ -144,7 +102,7 @@ export const BattlegroupCard = (
                 help_text: "",
                 extra_text: "",
                 brief_text: uiParent.briefText,
-                icon_name: getBattlegroupIcon(id, race),
+                icon_name: uiParent.iconName,
               }}
               time_cost={{
                 fuel: undefined,

--- a/components/unit-cards/unit-squad-card.tsx
+++ b/components/unit-cards/unit-squad-card.tsx
@@ -100,21 +100,25 @@ export const UnitSquadCard = ({ id, sight, moving, health, ui, type }: UnitSquad
           </Flex>
         </Grid.Col>
 
-        <Grid.Col span={4}>
-          <Flex gap={4} align="center" justify="space-between">
-            <Group spacing={4}>
-              <ImageWithFallback
-                height={32}
-                width={32}
-                fallbackSrc={symbolPlaceholder}
-                src={UnitSquadIcons["infantry_armor"]}
-                alt="squad armor (infantry only)"
-              ></ImageWithFallback>
-              <Text>Armor (Infantry)</Text>
-            </Group>
-            <Text align="end">{health?.armor || 0}</Text>
-          </Flex>
-        </Grid.Col>
+        {type !== "vehicles" ? (
+          <Grid.Col span={4}>
+            <Flex gap={4} align="center" justify="space-between">
+              <Group spacing={4}>
+                <ImageWithFallback
+                  height={32}
+                  width={32}
+                  fallbackSrc={symbolPlaceholder}
+                  src={UnitSquadIcons["infantry_armor"]}
+                  alt="squad armor (infantry only)"
+                ></ImageWithFallback>
+                <Text>Armor</Text>
+              </Group>
+              <Text align="end">{health?.armor || 0}</Text>
+            </Flex>
+          </Grid.Col>
+        ) : (
+          <></>
+        )}
       </Grid>
 
       {type === "vehicles" ? (

--- a/components/unit-cards/weapon-loadout-card.tsx
+++ b/components/unit-cards/weapon-loadout-card.tsx
@@ -117,7 +117,7 @@ export const WeaponLoadoutCard = (
 
         <Grid gutter="xs">
           <Grid.Col md={4} span={4}>
-            <Text>Round per minutes (RPM)</Text>
+            <Text>Rounds per minute (RPM)</Text>
           </Grid.Col>
           <Grid.Col md={3} span={3}>
             <Text align="center" color="green.6">

--- a/pages/explorer/races/[raceId]/units/[unitId].tsx
+++ b/pages/explorer/races/[raceId]/units/[unitId].tsx
@@ -65,8 +65,8 @@ const UnitDetail: NextPage<UnitDetailProps> = ({
   }
 
   // The resolved entity does not matter at all, as we can obtain such from the squad loadout.
-  console.log("🚀 ~ file: [unitId].tsx:35 ~ resolvedSquad:", resolvedSquad);
-  console.log("🚀 ~ file: [unitId].tsx:35 ~ resolvedEntities:", resolvedEntities);
+  // console.log("🚀 ~ file: [unitId].tsx:35 ~ resolvedSquad:", resolvedSquad);
+  // console.log("🚀 ~ file: [unitId].tsx:35 ~ resolvedEntities:", resolvedEntities);
 
   if (!resolvedSquad || !resolvedEntities?.length) {
     // How to redirect back?
@@ -76,14 +76,31 @@ const UnitDetail: NextPage<UnitDetailProps> = ({
   const localizedRace = localizedNames[raceId];
   const descriptionRace = RaceBagDescription[raceId];
 
+  // For team_weapons, get default members.
+  let defaultSquadMember: EbpsType;
+  if (resolvedSquad.unitType === "team_weapons" && resolvedSquad.loadout.length > 1) {
+    defaultSquadMember = resolvedEntities[resolvedEntities.length - 1];
+  } else {
+    defaultSquadMember = resolvedEntities[0];
+  }
+
   // Only vehicles have armor values and a single entity usually. The infantry
   // uses the plain `armor`.
   const armorValues = {
-    armor: resolvedEntities[0].health.armorLayout.armor || 0,
-    frontal: resolvedEntities[0].health.armorLayout.frontArmor || 0,
-    side: resolvedEntities[0].health.armorLayout.sideArmor || 0,
-    rear: resolvedEntities[0].health.armorLayout.rearArmor || 0,
-    targetSize: resolvedEntities[0].health.targetSize || 0,
+    armor: defaultSquadMember.health.armorLayout.armor || 0,
+    frontal: defaultSquadMember.health.armorLayout.frontArmor || 0,
+    side: defaultSquadMember.health.armorLayout.sideArmor || 0,
+    rear: defaultSquadMember.health.armorLayout.rearArmor || 0,
+    targetSize: defaultSquadMember.health.targetSize || 0,
+  };
+
+  const sightValues = {
+    coneAngle: defaultSquadMember.sight_ext.sight_package.cone_angle,
+    outerRadius: defaultSquadMember.sight_ext.sight_package.outer_radius,
+  };
+  const movingValues = {
+    defaultSpeed: defaultSquadMember.moving_ext.speed_scaling_table.default_speed,
+    maxSpeed: defaultSquadMember.moving_ext.speed_scaling_table.max_speed,
   };
 
   // Obtain the total cost of the squad by looking at the loadout.
@@ -146,15 +163,8 @@ const UnitDetail: NextPage<UnitDetailProps> = ({
                   ui: {
                     armorIcon: resolvedSquad.ui.armorIcon,
                   },
-                  sight: {
-                    coneAngle: resolvedEntities[0].sight_ext.sight_package.cone_angle,
-                    outerRadius: resolvedEntities[0].sight_ext.sight_package.outer_radius,
-                  },
-                  moving: {
-                    defaultSpeed:
-                      resolvedEntities[0].moving_ext.speed_scaling_table.default_speed,
-                    maxSpeed: resolvedEntities[0].moving_ext.speed_scaling_table.max_speed,
-                  },
+                  sight: sightValues,
+                  moving: movingValues,
                 })}
               </Card>
               {UnitUpgradeSection(resolvedSquad, upgradesData)}
@@ -180,16 +190,6 @@ const UnitDetail: NextPage<UnitDetailProps> = ({
                   three={resolvedSquad.veterancyInfo.three}
                 ></VeterancyCard>
               </Card>
-              {/* {resolvedSquad.unitType === "vehicles" ? (
-                <Card p="lg" radius="md" withBorder>
-                  <StatsVehicleArmor
-                    type={resolvedSquad.ui.armorIcon as VehicleArmorType}
-                    armorValues={armorValues}
-                  ></StatsVehicleArmor>
-                </Card>
-              ) : (
-                <></>
-              )} */}
             </Stack>
           </Grid.Col>
         </Grid>

--- a/src/unitStats/battlegroup.ts
+++ b/src/unitStats/battlegroup.ts
@@ -20,6 +20,9 @@ type BattleGroupUpgradeType = {
    * ability and the upgrade) and `costs_to_player` fields that we require for
    * displaying the ability info. */
   ability: AbilitiesType;
+  /** A list of unit spawnable items. This is used for workarounds to re-direct
+   * those abilities that call-in a squad. */
+  spawnItems: string[];
 };
 
 export type BattlegroupResolvedBranchType = {
@@ -73,6 +76,7 @@ export function resolveBattlegroupBranches(
           leftBranchUpgrades.push({
             upg: foundUpgrade,
             ability: foundAbility,
+            spawnItems: [],
           });
         }
       }
@@ -90,6 +94,7 @@ export function resolveBattlegroupBranches(
           rightBranchUpgrades.push({
             upg: foundUpgrade,
             ability: foundAbility,
+            spawnItems: [],
           });
         }
       }

--- a/src/unitStats/mappingEbps.ts
+++ b/src/unitStats/mappingEbps.ts
@@ -336,6 +336,7 @@ const getEbpsStats = async () => {
 
       // filter by relevant entity types
       switch (item.unitType) {
+        case "emplacements": // Buildable outside base (AA guns, AT guns).
         case "production": // Base buildings.
         case "infantry": // General infantry
         // case "flame_throwers":

--- a/src/unitStats/mappingSbps.ts
+++ b/src/unitStats/mappingSbps.ts
@@ -253,6 +253,7 @@ const getSbpsStats = async () => {
 
       // filter by relevant weapon types
       switch (item.unitType) {
+        case "emplacements": // Buildable outside base (AA guns, AT guns).
         case "infantry": // General infantry.
         case "team_weapons": // MGs, artillery (the mobile ones).
         case "vehicles": // General vehicles (tanks, armoured cars).

--- a/src/unitStats/workarounds.ts
+++ b/src/unitStats/workarounds.ts
@@ -1,0 +1,382 @@
+import { BattlegroupResolvedType } from "./battlegroup";
+import { SbpsType } from "./mappingSbps";
+
+type ItemType = SbpsType | BattlegroupResolvedType;
+
+interface Override {
+  /** */
+  predicate: (item: ItemType) => boolean;
+  /** */
+  mutator: (item: ItemType) => void;
+  /** */
+  validator?: (item: ItemType) => boolean;
+}
+
+function bgWorkaround(description: string, override: Override) {
+  bgWorkarounds.set(description, override);
+}
+
+const bgWorkarounds = new Map<string, Override>();
+
+// --------------------- BATTLEGROUPS --------------------- //
+
+function setBattlegroupsWorkarounds() {
+  /** Template */
+  // bgWorkaround("Modify Faction - xxxxxx BG Call-Ins", {
+  //   predicate: (item) =>
+  //     item.faction === "races/faction" && item.id === "yyyyyy",
+  //   mutator: (item) => {
+  //     item = item as BattlegroupResolvedType;
+  //     // A Branch.
+  //     item.branches.LEFT.upgrades.forEach((upg) => {
+  //       switch (upg.ability.id) {
+  //         case "":
+  //           upg.spawnItems = [""];
+  //           break;
+  //         case "":
+  //           upg.spawnItems = [""];
+  //           break;
+  //       }
+  //     });
+  //     // B Branch.
+  //     item.branches.RIGHT.upgrades.forEach((upg) => {
+  //       switch (upg.ability.id) {
+  //         case "":
+  //           upg.spawnItems = [""];
+  //           break;
+  //         case "":
+  //           upg.spawnItems = [""];
+  //           break;
+  //       }
+  //     });
+  //   },
+  // });
+
+  bgWorkaround("Modify Afrika Korps - Armored Support BG Call-Ins", {
+    predicate: (item) => item.faction === "races/afrika_korps" && item.id === "armored_support",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Armored Warfare branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "armored_support_flame_p3_ak":
+            upg.spawnItems = ["panzer_iii_flame_ak"];
+            break;
+          case "armored_support_command_p4_ak":
+            upg.spawnItems = ["panzer_iv_command_ak"];
+            break;
+        }
+      });
+    },
+  });
+  bgWorkaround("Modify Afrika Korps - Italian Combined Arms BG Call-Ins", {
+    predicate: (item) =>
+      item.faction === "races/afrika_korps" && item.id === "italian_combined_arms",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Combined Arms Branch.
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "italian_combined_arms_bersaglieri_ak":
+            upg.spawnItems = ["bersaglieri_ak"];
+            break;
+        }
+      });
+      // Italian Armor Branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "italian_combined_arms_semovente_ak":
+            upg.spawnItems = ["semovente_75_18_ak"];
+            break;
+          case "italian_combined_arms_m13_40_ak":
+            upg.spawnItems = ["m13_40_ak"];
+            break;
+        }
+      });
+    },
+  });
+  bgWorkaround("Modify Afrika Korps - Italian Infantry BG Call-Ins", {
+    predicate: (item) => item.faction === "races/afrika_korps" && item.id === "italian_infantry",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Field Engineering Branch.
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "italian_infantry_guastatori_ak":
+            upg.spawnItems = ["guastatori_ak"];
+            break;
+          case "italian_infantry_cannone_da_105_ak":
+            upg.spawnItems = ["howitzer_cannone_da_105_ak"];
+            break;
+        }
+      });
+      // Defensive Warfare Branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "italian_infantry_double_l640_ak":
+            upg.spawnItems = ["l6_40_ak", "l6_40_ak"];
+            break;
+        }
+      });
+    },
+  });
+
+  bgWorkaround("Modify British - Air and Sea BG Call-Ins", {
+    predicate: (item) => item.faction === "races/british" && item.id === "british_air_and_sea",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Royal Navy Support branch.
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "british_air_and_sea_left_2a_centaur_cs_uk":
+            upg.spawnItems = ["centaur_africa_uk"];
+            break;
+        }
+      });
+      // Royal Air Force branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "british_air_and_sea_right_1_commandos_uk":
+            upg.spawnItems = ["commando_africa_uk"];
+            break;
+          case "british_air_and_sea_right_2a_pack_howitzer_team_uk":
+            upg.spawnItems = ["pack_howitzer_75mm_africa_uk"];
+            break;
+          case "british_air_and_sea_right_2b_commando_lmg_team_uk":
+            upg.spawnItems = ["commando_lmg_africa_uk"];
+            break;
+        }
+      });
+    },
+  });
+  bgWorkaround("Modify British - British Armored BG Call-Ins", {
+    predicate: (item) => item.faction === "races/british" && item.id === "british_armored",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Heavy Armor Support
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "british_armored_right_2_crusader_aa_uk":
+            upg.spawnItems = ["crusader_aa_africa_uk"];
+            break;
+          case "british_armored_left_2_churchill":
+            upg.spawnItems = ["churchill_africa_uk"];
+            break;
+          case "british_armored_left_3b_churchill_black_prince_uk":
+            upg.spawnItems = ["churchill_black_prince_africa_uk"];
+            break;
+        }
+      });
+      // Field Support and Logistics Branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          // Do nothing.
+          default:
+            break;
+        }
+      });
+    },
+  });
+  bgWorkaround("Modify British - Indian Artillery BG Call-Ins", {
+    predicate: (item) => item.faction === "races/british" && item.id === "indian_artillery",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Infantry Assault Branch.
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "artillery_gurkhas_uk":
+            upg.spawnItems = ["gurkhas_africa_uk"];
+            break;
+        }
+      });
+      // Artillery Support Branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "artillery_4_2_inch_heavy_mortar_uk":
+            upg.spawnItems = ["mortar_heavy_4_2_africa_uk"];
+            break;
+          case "artillery_bl_5_5_heavy_artillery_uk":
+            upg.spawnItems = ["howitzer_bl_5_5_africa_uk"];
+            break;
+        }
+      });
+    },
+  });
+
+  bgWorkaround("Modify American - Airborne BG Call-Ins", {
+    predicate: (item) => item.faction === "races/american" && item.id === "airborne",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Aerial Support Branch.
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          // Do nothing.
+          default:
+            break;
+        }
+      });
+      // Paradropped Infantry Branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "airborne_right_1b_paradrop_hmg_us":
+            upg.spawnItems = ["hmg_30cal_paradrop_us"];
+            break;
+          case "airborne_right_2_paratrooper_us":
+            upg.spawnItems = ["paratrooper_us"];
+            break;
+          case "airborne_right_3_paradrop_at_gun_us":
+            upg.spawnItems = ["at_gun_57mm_paradrop_us"];
+            break;
+        }
+      });
+    },
+  });
+  bgWorkaround("Modify American - Armored BG Call-Ins", {
+    predicate: (item) => item.faction === "races/american" && item.id === "armored",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Engineering Corp Branch.
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "armored_left_2b_recovery_vehicle_us":
+            upg.spawnItems = ["recovery_vehicle_us"];
+            break;
+        }
+      });
+      // Armored Doctrine Branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "armored_right_2a_scott_us":
+            upg.spawnItems = ["scott_us"];
+            break;
+          case "armored_right_3_sherman_easy_8_us":
+            upg.spawnItems = ["sherman_easy_8_us"];
+            break;
+        }
+      });
+    },
+  });
+  bgWorkaround("Modify American - Special Operations BG Call-Ins", {
+    predicate: (item) => item.faction === "races/american" && item.id === "special_operations",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Combat Support Branch.
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "special_operations_left_1a_m29_weasal_us":
+            upg.spawnItems = ["m29_weasal_us"];
+            break;
+          case "special_operations_left_1b_m29_weasal_with_pack_howitzer":
+            upg.spawnItems = ["m29_weasal_us", "engineer_us"];
+            break;
+          case "special_operations_left_3_whizbang_us":
+            upg.spawnItems = ["sherman_whizbang_us"];
+            break;
+        }
+      });
+      // Combat Operations Branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "special_operations_right_3a_assault_operation_us":
+            upg.spawnItems = ["ssf_commandos_us"];
+            break;
+        }
+      });
+    },
+  });
+
+  bgWorkaround("Modify German - Breakthrough BG Call-Ins", {
+    predicate: (item) => item.faction === "races/german" && item.id === "breakthrough",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Assault Forces Branch.
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "breakthrough_right_3a_assault_group_ger":
+            upg.spawnItems = ["stormtrooper_ger", "halftrack_ger"];
+            break;
+        }
+      });
+      // Armored Offensive Branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "breakthrough_left_1b_truck_2_5_ger":
+            upg.spawnItems = ["truck_2_5_cargo_ger"];
+            break;
+          case "breakthrough_left_2b_panzer_iv_cmd_ger":
+            upg.spawnItems = ["panzer_iv_cmd_ger"];
+            break;
+          case "breakthrough_left_3_tiger_ger":
+            upg.spawnItems = ["tiger_ger"];
+            break;
+        }
+      });
+    },
+  });
+  bgWorkaround("Modify German - Luftwaffe BG Call-Ins", {
+    predicate: (item) => item.faction === "races/german" && item.id === "luftwaffe",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Luftwaffe Air-to-Ground Support Branch.
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "luftwaffe_right_2_fallschirmjagers_ger":
+            upg.spawnItems = ["fallschirmjagers_ger"];
+            break;
+        }
+      });
+      // Luftwaffe Field Support Branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "luftwaffe_left_1b_fallschirmpioneers_ger":
+            upg.spawnItems = ["fallschirmpioneers_ger"];
+            break;
+          case "luftwaffe_left_2b_combat_group_ger":
+            upg.spawnItems = ["wirbelwind_ger", "jaeger_ger"];
+            break;
+          case "luftwaffe_left_2a_weapon_drop_ger":
+            upg.spawnItems = ["at_gun_lg40_ger"];
+            break;
+          case "luftwaffe_left_3_88mm_at_gun_ger":
+            /** The ability enables building the emplacement. */
+            upg.spawnItems = ["aa_gun_20mm_emplacement_ger"];
+            break;
+        }
+      });
+    },
+  });
+  bgWorkaround("Modify German - Mechanized BG Call-Ins", {
+    predicate: (item) => item.faction === "races/german" && item.id === "mechanized",
+    mutator: (item) => {
+      item = item as BattlegroupResolvedType;
+      // Mechanized Armor Branch.
+      item.branches.LEFT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "mechanized_right_2a_stug_assault_group_ger":
+            upg.spawnItems = ["stug_iii_d_ger"];
+            break;
+          case "mechanized_left_2b_8_rad_ger":
+            upg.spawnItems = ["armored_car_8_rad_ger"];
+            break;
+          case "mechanized_right_3_panther_ger":
+            upg.spawnItems = ["panther_ger"];
+            break;
+        }
+      });
+      // Mechanized Support Branch.
+      item.branches.RIGHT.upgrades.forEach((upg) => {
+        switch (upg.ability.id) {
+          case "mechanized_left_3a_wespe_ger":
+            upg.spawnItems = ["wespe_ger"];
+            break;
+        }
+      });
+    },
+  });
+}
+
+setBattlegroupsWorkarounds();
+
+console.log(`Total BG workarounds: ${bgWorkarounds.size}`);
+
+export { bgWorkarounds };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "downlevelIteration": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Bugfixes

- No longer need manual mapping for battlegroup icons.
- Reused `getSbpsWeapons` function, which fixed weapon cards loadout at unit page.
- Correctly compute soft stats based on default squad entity (ebps). Wasn't working well for team weapons.
- Battlegroups workaround to properly map the call-ins and redirect to unit page on click.