### PR TITLE
copy change for players online

### DIFF
--- a/components/online-players.tsx
+++ b/components/online-players.tsx
@@ -31,7 +31,7 @@ export const OnlinePlayers: React.FC = () => {
       ).toLocaleString()}`}
     >
       <div>
-        Players Online{" "}
+        Players in game{" "}
         <Badge color="green" variant="filled" size="lg" style={{ minWidth: 60 }}>
           {onlinePlayersData?.playerCount}
         </Badge>

--- a/components/online-players.tsx
+++ b/components/online-players.tsx
@@ -31,7 +31,7 @@ export const OnlinePlayers: React.FC = () => {
       ).toLocaleString()}`}
     >
       <div>
-        Ingame players{" "}
+        Players Online{" "}
         <Badge color="green" variant="filled" size="lg" style={{ minWidth: 60 }}>
           {onlinePlayersData?.playerCount}
         </Badge>


### PR DESCRIPTION
@petrvecera hey sorry to nitpick, but `ingame players` to be correct I'm pretty sure should be `In game players`.
I prefer `players online` or maybe `players in game` but however you like of course, it doesn't make a big difference to me. Just think it should be fixed to one of these.