### PR TITLE
fix: player-card body used error

### DIFF
--- a/src/coh3stats-api.ts
+++ b/src/coh3stats-api.ts
@@ -41,7 +41,6 @@ const getPlayerCardInfo = async (playerID: string | number) => {
     return data;
   } else {
     if (response.status === 500) {
-      const data = await response.json();
       throw new Error(`Error getting player card info: ${data.error}`);
     }
     throw new Error(`Error getting player card info`);


### PR DESCRIPTION
#163 

if we call json() or text() twice, fetch will throw body used for error

![image](https://user-images.githubusercontent.com/83199839/229540498-3b70f6a3-fd4e-4e9b-9ef0-1b55d878828a.png)
