### PR TITLE
fix: 500 error when referer has the same playerID

### DIFF
--- a/components/matches-table/render-players.tsx
+++ b/components/matches-table/render-players.tsx
@@ -55,6 +55,7 @@ const RenderPlayers = ({ playerReports, profileID }: RenderPlayersProps) => {
               <FactionIcon name={raceIDs[playerInfo.race_id as raceID]} width={20} />
               <> {ratingElement}</>
               <Anchor
+                rel={"noreferrer"}
                 key={playerInfo.profile_id}
                 component={Link}
                 href={`/players/${playerInfo.profile_id}`}


### PR DESCRIPTION
#167 

when we open a link which is the same player as current player in a new tab, referer is the same as url.it will cause 500 error because if referer is the same and playerId is the same mean is that we should have playerData, but we don't have. 

so this solution is just not passing referer when we open a link on recentMatches.
