### PR TITLE
Workaround new fixes 114

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -46,7 +46,7 @@ const latestPatch = "1.1.4";
 
 const patches: Record<string, { dataTag: string; dataTime: string }> = {
   "1.1.4": {
-    dataTag: "v1.1.4-1", // This is the tag of the data repo
+    dataTag: "v1.1.4-2", // This is the tag of the data repo
     dataTime: "20/April/2023", // The date when was the data tag created (the data extracted from game)
   },
   "1.1.3": {

--- a/src/unitStats/mappingEbps.ts
+++ b/src/unitStats/mappingEbps.ts
@@ -4,6 +4,7 @@ import { resolveLocstring } from "./locstring";
 import { isBaseFaction, traverseTree } from "./unitStatsLib";
 import config from "../../config";
 import { internalSlash } from "../utils";
+import { ebpsWorkarounds } from "./workarounds";
 
 // need to be extended by all required fields
 type EbpsType = {
@@ -364,6 +365,19 @@ const getEbpsStats = async (patch = "latest") => {
           return;
       }
     });
+  }
+
+  for (const ebpsItem of ebpsSetAll) {
+    for (const [override, { predicate, mutator, validator }] of ebpsWorkarounds) {
+      if (predicate(ebpsItem)) {
+        mutator(ebpsItem);
+        // console.info(`Overriding ${ebpsItem.id} with ${override}`);
+        if (validator && !validator(ebpsItem)) {
+          console.error(`Invalid item ${ebpsItem.id} after override ${override}`, ebpsItem);
+          // throw new Error("Error during bg workarounds");
+        }
+      }
+    }
   }
 
   if (!EbpsPatchData) EbpsPatchData = {};

--- a/src/unitStats/workarounds.ts
+++ b/src/unitStats/workarounds.ts
@@ -277,7 +277,7 @@ function setBattlegroupsWorkarounds() {
       // Combat Operations Branch.
       item.branches.RIGHT.upgrades.forEach((upg) => {
         switch (upg.ability.id) {
-          case "special_operations_right_3a_assault_operation_us":
+          case "special_operations_right_2_devils_brigade_us":
             upg.spawnItems = ["ssf_commandos_us"];
             break;
         }

--- a/src/unitStats/workarounds.ts
+++ b/src/unitStats/workarounds.ts
@@ -256,7 +256,7 @@ function setBattlegroupsWorkarounds() {
           case "armored_right_2a_scott_us":
             upg.spawnItems = ["scott_us"];
             break;
-          case "armored_right_3_sherman_easy_8_us":
+          case "armored_right_3_easy_8_task_force_us":
             upg.spawnItems = ["sherman_easy_8_us"];
             break;
         }

--- a/src/unitStats/workarounds.ts
+++ b/src/unitStats/workarounds.ts
@@ -1,7 +1,8 @@
 import { BattlegroupResolvedType } from "./battlegroup";
+import { EbpsType } from "./mappingEbps";
 import { SbpsType } from "./mappingSbps";
 
-type ItemType = SbpsType | BattlegroupResolvedType;
+type ItemType = EbpsType | SbpsType | BattlegroupResolvedType;
 
 interface Override {
   /** */
@@ -17,6 +18,12 @@ function bgWorkaround(description: string, override: Override) {
 }
 
 const bgWorkarounds = new Map<string, Override>();
+
+function ebpsWorkaround(description: string, override: Override) {
+  ebpsWorkarounds.set(description, override);
+}
+
+const ebpsWorkarounds = new Map<string, Override>();
 
 // --------------------- BATTLEGROUPS --------------------- //
 
@@ -375,8 +382,23 @@ function setBattlegroupsWorkarounds() {
   });
 }
 
+function setUnitWeaponWorkarounds() {
+  ebpsWorkaround("Modify American - Weasel Default Weapon", {
+    predicate: (item) => item.faction === "american" && item.id === "m29_weasal_us",
+    mutator: (item) => {
+      item = item as EbpsType;
+      item.weaponRef.push({
+        type: "default",
+        ebp: "ebps/races/american/weapons/small_arms/machine_guns/heavy_machine_gun/w_30cal_weasal_us",
+      });
+    },
+  });
+}
+
 setBattlegroupsWorkarounds();
+setUnitWeaponWorkarounds();
 
 console.log(`Total BG workarounds: ${bgWorkarounds.size}`);
+console.log(`Total EBPS workarounds: ${ebpsWorkarounds.size}`);
 
-export { bgWorkarounds };
+export { bgWorkarounds, ebpsWorkarounds };


### PR DESCRIPTION
This should fix the missing weasel default weapon and also use the latest data so the battlegroups match the latest update (v1.1.4).

Also properly map the squad of the Spec Ops battlegroup that call-ins the commandos.