### PR TITLE
Fix displaying of the scatter area on weapons cards

### DIFF
--- a/__tests__/src/unitStats/weaponLib.test.ts
+++ b/__tests__/src/unitStats/weaponLib.test.ts
@@ -1,0 +1,26 @@
+import { getScatterArea, WeaponStatsType } from "../../../src/unitStats";
+
+describe("getScatterArea", () => {
+  // Marauder 3 data
+  const mockWeaponBag = {
+    scatter_distance_scatter_offset: 0.25,
+    scatter_distance_scatter_max: 4,
+    scatter_angle_scatter: 5,
+    scatter_distance_scatter_ratio: 1,
+  };
+
+  test("Should calculate Marauder 3 correctly for distance 10", () => {
+    const scatter = getScatterArea(10, mockWeaponBag as WeaponStatsType);
+    expect(scatter).toBe(7.679448708775048);
+  });
+
+  test("Should calculate Marauder 3 correctly for distance 30", () => {
+    const scatter = getScatterArea(30, mockWeaponBag as WeaponStatsType);
+    expect(scatter).toBe(21.642082724729686);
+  });
+
+  test("Should calculate Marauder 3 correctly for distance 50", () => {
+    const scatter = getScatterArea(50, mockWeaponBag as WeaponStatsType);
+    expect(scatter).toBe(35.604716740684324);
+  });
+});

--- a/components/unit-cards/weapon-loadout-card.tsx
+++ b/components/unit-cards/weapon-loadout-card.tsx
@@ -40,7 +40,7 @@ export const WeaponLoadoutCard = (
               src={iconName}
               alt={id}
               fallbackSrc={symbolPlaceholder}
-            ></ImageWithFallback>
+            />
           ) : (
             <Image width={48} height={16} src={iconName} alt={id}></Image>
           )}
@@ -55,7 +55,7 @@ export const WeaponLoadoutCard = (
         </Flex>
       </Flex>
 
-      <Divider></Divider>
+      <Divider />
 
       <Stack spacing={2} fz="sm">
         {/* Section Group Header */}
@@ -193,7 +193,7 @@ export const WeaponLoadoutCard = (
           <Grid.Col md={2} span={2}>
             <Text align="center" color="red.6">
               {isBallisticOrExplosive
-                ? Math.round(getScatterArea(weapon_bag.range.far, weapon_bag))
+                ? Math.round(getScatterArea(weapon_bag.range.max, weapon_bag))
                 : "-"}
             </Text>
           </Grid.Col>


### PR DESCRIPTION
The scatter area takes in the distance. For FAR we showed distance.max but we used for scatter .far , which was sometimes -1. By using .max , it should align the scatter together with the distance we display. 