### PR TITLE
Fix the naming of the Pachino map

### DIFF
--- a/src/coh3/coh3-data.ts
+++ b/src/coh3/coh3-data.ts
@@ -475,8 +475,12 @@ const maps: { [key: string]: { name: string; url: string } } = {
     name: "Gardens",
     url: "/icons/maps/gardens.webp",
   },
-  rural_town_2p_mkii: {
+  pachino_2p: {
     name: "Pachino Stalemate",
+    url: "/icons/maps/pachino_farmlands_mkii.webp",
+  },
+  rural_town_2p_mkii: {
+    name: "Pachino Farmlands",
     url: "/icons/maps/pachino_farmlands_mkii.webp",
   },
   monte_cavo_8p: {


### PR DESCRIPTION
![image](https://github.com/cohstats/coh3-stats/assets/8086995/895ed5e4-fcf6-4ebf-aa2c-40dd6a294f12)

The map is under a new name 

![image](https://github.com/cohstats/coh3-stats/assets/8086995/5159a284-e89b-47a9-a949-935528766960)
