### PR TITLE
Unit Stats - Cost Correction

### DIFF
--- a/pages/explorer/races/[raceId].tsx
+++ b/pages/explorer/races/[raceId].tsx
@@ -129,13 +129,16 @@ const BuildingMapping = (
   return (
     <Stack>
       {buildings.map((building) => {
+        const spawnerRefs = Object.values(building.spawner_ext.spawn_items).map(
+          (x) => x.squad.instance_reference,
+        );
         // Temporary workaround while a better idea to display call-ins of DAK shows up.
         const upgrades =
           race === "dak" && building.id === "halftrack_deployment_ak"
             ? generateAfrikaKorpsCallIns(data.abilitiesData)
             : getBuildingUpgrades(building, data.upgradesData);
         const units = Object.values(
-          getResolvedSquads(building.spawnItems, data.sbpsData, data.ebpsData),
+          getResolvedSquads(spawnerRefs, data.sbpsData, data.ebpsData),
         ).map((unit) => ({
           ...unit,
           playerReq: Object.values(getResolvedUpgrades(unit.requirements, data.upgradesData)),

--- a/src/unitStats/faction.ts
+++ b/src/unitStats/faction.ts
@@ -188,7 +188,7 @@ function generateAfrikaKorpsCallInsBuilding(): EbpsType {
     faction: "afrika_corps",
     unitType: "production",
     unitTypes: ["halftrack_deployment"],
-    spawnItems: [],
+    spawner_ext: { spawn_items: {} },
     crew_size: 0, // Chrida: crewsize added / was missing.
     cost: {
       fuel: 0,

--- a/src/unitStats/squadTotalCost.ts
+++ b/src/unitStats/squadTotalCost.ts
@@ -37,12 +37,18 @@ export function getSquadTotalCost(sbpsUnit: SbpsType, ebpsData: EbpsType[]) {
     ...loadout,
     id: loadout.type.split("/").slice(-1)[0], // Provides id match 1:1 between ebps <-> sbps.
   }));
-  // Simply multiply the total numbers of all loadouts with a single
-  // instance cost. they should all have the same.
+  // Simply multiply the total numbers of all loadouts with a single instance
+  // cost. they should all have the same.
   const ebpsUnits = loadouts.map((loadout) => ({
     loadout,
     entity: ebpsData.find((x) => x.id === loadout.id),
   }));
+
+  // Lookup for the building that spawn each ebps item and add the
+  // `item_cost_adjustment` from that if applies.
+  const adjustedCost = ebpsData.find((x) => sbpsUnit.id in x.spawner_ext.spawn_items)?.spawner_ext
+    .spawn_items[sbpsUnit.id].item_cost_adjustment;
+
   /**
    * Important note found in the editor from designer:
    * - The population cost of this SQUAD is stored as
@@ -59,10 +65,10 @@ export function getSquadTotalCost(sbpsUnit: SbpsType, ebpsData: EbpsType[]) {
       return tc;
     },
     {
-      fuel: 0,
-      manpower: 0,
-      munition: 0,
-      popcap: sbpsUnit.populationExt.personnel_pop,
+      fuel: adjustedCost?.fuel || 0,
+      manpower: adjustedCost?.manpower || 0,
+      munition: adjustedCost?.munition || 0,
+      popcap: sbpsUnit.populationExt.personnel_pop + (adjustedCost?.popcap || 0),
       time_seconds: 0,
       command: 0,
     },


### PR DESCRIPTION
## What it contains?

Fixes several squad displaying the wrong cost due to a combination of two factors:

- We were ignoring the unit cost correcting listed within the `spawner_ext` of the buildings `ebps` files.
- The workaround we applied via mod at coh3-data for the towed guns, which should be removed after [this PR is merged](https://github.com/cohstats/coh3-data/pull/40).

## Fixed

- Panzerjaeger cost is wrong.
- Some team weapon costs are wrong (i.e. Ie.fh 18).
- 17 Pounder cost is wrong.
- Flak 88mm cost is wrong.