### PR TITLE
Fix/overlapping image issue

### DIFF
--- a/screens/desktop-app/desktop-app.module.css
+++ b/screens/desktop-app/desktop-app.module.css
@@ -1,5 +1,28 @@
-.desktop-app-image {
+.desktop-app-image-container {
   max-width: 900px;
-  max-height: 500px;
-  min-height: 190px;
+  height: 550px;
+  position: relative;
+  margin: 0 auto;
+}
+
+.desktop-app-loading-image {
+  width: 100%;
+  height: 80%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  object-fit: cover;
+}
+
+.desktop-app-image {
+  width: 60%;
+  height: auto;
+  object-fit: contain;
+  position: absolute;
+  top: 65%;
+  left: 45%;
+  transform: translate(0%, -50%);
+  z-index: 1;
+  box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.5);
+  border-radius: 8px;
 }

--- a/screens/desktop-app/desktop-app.module.css
+++ b/screens/desktop-app/desktop-app.module.css
@@ -1,5 +1,5 @@
 .desktop-app-image-container {
-  max-width: 900px;
+  max-width: 800px;
   height: 550px;
   position: relative;
   margin: 0 auto;
@@ -15,12 +15,12 @@
 }
 
 .desktop-app-image {
-  width: 60%;
+  width: 65%;
   height: auto;
   object-fit: contain;
   position: absolute;
-  top: 65%;
-  left: 45%;
+  top: 75%;
+  left: 60%;
   transform: translate(0%, -50%);
   z-index: 1;
   box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.5);

--- a/screens/desktop-app/index.tsx
+++ b/screens/desktop-app/index.tsx
@@ -40,13 +40,23 @@ const DesktopAppPage: NextPage = ({ downloadURL, downloadCount, version }: any) 
       </Head>
       <Container size={"lg"}>
         {/*We need to fix this on both mobile and desktop to avoid CLS*/}
-        <Image
-          src="/desktop-app/desktop-app-main.webp"
-          alt={"coh3 stats desktop app"}
-          radius="md"
-          mx="auto"
-          className={classes["desktop-app-image"]}
-        />
+
+        <div className={classes["desktop-app-image-container"]}>
+          <Image
+            src="/desktop-app/desktop-app-loading-v2.webp"
+            alt={"coh3 stats desktop app loading image"}
+            radius="md"
+            mx="auto"
+            className={classes["desktop-app-loading-image"]}
+          />
+          <Image
+            src="/desktop-app/desktop-app-v2.webp"
+            alt={"coh3 stats desktop app"}
+            radius="md"
+            mx="auto"
+            className={classes["desktop-app-image"]}
+          />
+        </div>
         <Paper radius="md" mt="md" p="lg">
           <Stack align="center" gap={5} mb={30}>
             <Anchor href={downloadURL} target="_blank">


### PR DESCRIPTION
### Display 2 images instead of 1 using CSS #591
<img width="1394" alt="Screenshot 2024-09-29 at 4 39 55 AM" src="https://github.com/user-attachments/assets/6762dd33-3715-4a9b-a687-cb103d26c904">


