### PR TITLE
make sidemenu sticky in about us page

### DIFF
--- a/screens/about/index.tsx
+++ b/screens/about/index.tsx
@@ -11,6 +11,7 @@ import {
   Divider,
   Space,
   Text,
+  Affix,
 } from "@mantine/core";
 //import { createStyles } from '@mantine/emotion';
 import React, { useEffect } from "react";
@@ -21,6 +22,7 @@ import DonateSection from "./DonateSection";
 import Link from "next/link";
 import config from "../../config";
 import DataSection from "./DataSection";
+import { useMediaQuery } from "@mantine/hooks";
 
 const BugReports = () => {
   return (
@@ -234,6 +236,8 @@ const About: NextPage = () => {
     AnalyticsAboutAppPageView();
   }, []);
 
+  const isMobile = useMediaQuery("(max-width: 768px)");
+
   return (
     <div>
       {/*This is custom HEAD overwrites the default one*/}
@@ -253,34 +257,41 @@ const About: NextPage = () => {
           {" "}
           <Grid>
             <Grid.Col span={3}>
-              <div
-                style={{
-                  display: "block",
-                  height: "65px",
+              <Affix
+                position={{
+                  top: isMobile ? 150 : 200,
+                  left: isMobile ? 15 : 80,
                 }}
               >
-                {sections.map((x) => {
-                  return (
-                    <Flex
-                      key={x.name}
-                      direction={{ base: "column" }}
-                      gap={{ base: "sm", sm: "lg" }}
-                    >
-                      <div>
-                        <Anchor
-                          href={`#${x.name}`}
-                          style={{
-                            color: "inherit",
-                          }}
-                        >
-                          {x.menuDisplayName}
-                        </Anchor>
-                        <Divider my="sm" />
-                      </div>
-                    </Flex>
-                  );
-                })}
-              </div>
+                <div
+                  style={{
+                    display: "block",
+                    height: "auto",
+                  }}
+                >
+                  {sections.map((x) => {
+                    return (
+                      <Flex
+                        key={x.name}
+                        direction={{ base: "column" }}
+                        gap={{ base: "sm", sm: "lg" }}
+                      >
+                        <div>
+                          <Anchor
+                            href={`#${x.name}`}
+                            style={{
+                              color: "inherit",
+                            }}
+                          >
+                            {x.menuDisplayName}
+                          </Anchor>
+                          <Divider my="sm" />
+                        </div>
+                      </Flex>
+                    );
+                  })}
+                </div>
+              </Affix>
             </Grid.Col>
 
             <Grid.Col span={9}>


### PR DESCRIPTION
About - Menu not sticking #557

### MOBILE
<img width="1277" alt="Screenshot 2024-10-02 at 3 06 24 AM" src="https://github.com/user-attachments/assets/235c8ad9-bd93-452b-9ce9-fe9036573c61">


### PC

<img width="1277" alt="Screenshot 2024-10-02 at 3 06 18 AM" src="https://github.com/user-attachments/assets/f12a7a77-fe40-4c19-93ef-38d8046e17a1">