### PR TITLE
Improve explorer unit card

### DIFF
--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="PrettierConfiguration">
+    <option name="myConfigurationMode" value="AUTOMATIC" />
     <option name="myRunOnReformat" value="true" />
   </component>
 </project>

--- a/components/faction-icon.tsx
+++ b/components/faction-icon.tsx
@@ -7,8 +7,17 @@ import americanIcon from "../public/icons/general/american.webp";
 import germanIcon from "../public/icons/general/german.webp";
 import britishIcon from "../public/icons/general/british.webp";
 import dakIcon from "../public/icons/general/dak.webp";
+import React from "react";
 
-const FactionIcon = ({ name, width }: { name: raceType; width: number }) => {
+const FactionIcon = ({
+  name,
+  width,
+  style,
+}: {
+  name: raceType;
+  width: number;
+  style?: React.CSSProperties;
+}) => {
   let icon = americanIcon;
 
   switch (name) {
@@ -26,7 +35,14 @@ const FactionIcon = ({ name, width }: { name: raceType; width: number }) => {
   }
 
   return (
-    <Image src={icon} alt={`${name} faction icon`} width={width} height={width} unoptimized />
+    <Image
+      src={icon}
+      alt={`${name} faction icon`}
+      width={width}
+      height={width}
+      style={style}
+      unoptimized
+    />
   );
 };
 

--- a/components/unit-cards/unit-description-card.tsx
+++ b/components/unit-cards/unit-description-card.tsx
@@ -73,7 +73,7 @@ export const UnitDescriptionCard = ({
               alt={`${desc.screen_name} symbol`}
               fallbackSrc={symbolPlaceholder}
             />
-            <Title order={4} style={{ textTransform: "capitalize" }} lineClamp={1}>
+            <Title order={list ? 4 : 2} style={{ textTransform: "capitalize" }} lineClamp={1}>
               {desc.screen_name}
             </Title>
           </Flex>

--- a/pages/explorer/races/[raceId].tsx
+++ b/pages/explorer/races/[raceId].tsx
@@ -133,7 +133,11 @@ const RaceDetail: NextPage<RaceDetailProps> = ({
         <Stack mt={32}>
           <Title order={4}>{descriptions.buildings}</Title>
 
-          <BuildingMapping preCalculatedBuildings={preCalculatedBuildings} t={t} />
+          <BuildingMapping
+            preCalculatedBuildings={preCalculatedBuildings}
+            t={t}
+            faction={raceToFetch}
+          />
         </Stack>
 
         {/*<Flex direction="row" gap={16} mt={24}>*/}
@@ -152,14 +156,17 @@ const RaceDetail: NextPage<RaceDetailProps> = ({
 /**
  * Updated BuildingMapping function that uses pre-calculated data
  * @param preCalculatedBuildings
+ * @param faction
  * @param t
  * @constructor
  */
 const BuildingMapping = ({
   preCalculatedBuildings,
+  faction,
   t,
 }: {
   preCalculatedBuildings: PreCalculatedBuilding[];
+  faction: raceType;
   t: (key: string) => string;
 }) => {
   return (
@@ -167,7 +174,7 @@ const BuildingMapping = ({
       {preCalculatedBuildings.map((building) => (
         <Card key={building.id} p="sm" radius="md" withBorder>
           <BuildingCard
-            faction={building.unitTypes[0]?.split("_")[0] as raceType}
+            faction={faction}
             types={building.unitTypes as BuildingType[]}
             desc={building.desc}
             units={building.units}

--- a/pages/explorer/races/[raceId]/units/[unitId].tsx
+++ b/pages/explorer/races/[raceId]/units/[unitId].tsx
@@ -5,11 +5,10 @@ import { useRouter } from "next/router";
 import {
   Card,
   Container,
-  Flex,
   Grid,
+  Group,
   List,
   SimpleGrid,
-  Space,
   Stack,
   Text,
   Title,
@@ -56,6 +55,8 @@ import { getUnitStatsCOH3Descriptions } from "../../../../../src/unitStats/descr
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import config from "../../../../../config";
+import { getExplorerFactionRoute } from "../../../../../src/routes";
+import Link from "next/link";
 
 interface UnitDetailProps {
   calculatedData: {
@@ -95,6 +96,8 @@ const UnitDetail: NextPage<UnitDetailProps> = ({ calculatedData, descriptions, l
   }
 
   const localizedRace = localizedNames[raceId];
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const descriptionRace = descriptions[raceId as raceType]?.description || null;
 
   // For team_weapons, get default members.
@@ -309,29 +312,32 @@ const UnitDetail: NextPage<UnitDetailProps> = ({ calculatedData, descriptions, l
 
         {generateAlternateLanguageLinks(asPath)}
       </Head>
-      <Container fluid p={0}>
-        <Flex direction="row" align="center" gap="md">
-          <FactionIcon name={raceId} width={80} />
-          <Stack gap="xs">
-            <Title order={3}>{localizedRace}</Title>
-            <Text size="md">{descriptionRace}</Text>
-          </Stack>
-        </Flex>
-        <Space h={"xl"} />
+      <Container fluid pl={0} pr={0} pt={"md"}>
         <Grid columns={3} grow>
           <Grid.Col span={3}>
-            <Card p="md" radius="md" withBorder>
-              <UnitDescriptionCard
-                faction={raceId}
-                desc={{
-                  screen_name: resolvedSquad.ui.screenName,
-                  help_text: resolvedSquad.ui.helpText,
-                  brief_text: resolvedSquad.ui.briefText,
-                  symbol_icon_name: resolvedSquad.ui.symbolIconName,
-                  icon_name: resolvedSquad.ui.iconName,
-                }}
-              />
-            </Card>
+            <Group align="stretch" gap="xl">
+              <Card p="md" radius="md" withBorder style={{ flex: 1 }}>
+                <UnitDescriptionCard
+                  faction={raceId}
+                  desc={{
+                    screen_name: resolvedSquad.ui.screenName,
+                    help_text: resolvedSquad.ui.helpText,
+                    brief_text: resolvedSquad.ui.briefText,
+                    symbol_icon_name: resolvedSquad.ui.symbolIconName,
+                    icon_name: resolvedSquad.ui.iconName,
+                  }}
+                />
+              </Card>
+              <div style={{ display: "flex", alignItems: "stretch" }}>
+                <Link href={getExplorerFactionRoute(raceId)}>
+                  <FactionIcon
+                    name={raceId}
+                    width={150}
+                    style={{ height: "100%", objectFit: "contain" }}
+                  />
+                </Link>
+              </div>
+            </Group>
           </Grid.Col>
           <Grid.Col span={{ md: 2, xs: 3 }} order={1}>
             <Stack>


### PR DESCRIPTION
Improves explorer unit card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Faction icons now support custom inline styles for greater flexibility.
  - Faction icons in unit detail views are larger and link directly to the faction explorer page.

- **Enhancements**
  - The heading level for unit titles adjusts based on context, improving visual hierarchy and accessibility.
  - Building mapping logic is streamlined by passing faction information directly, ensuring more consistent data handling.

- **Chores**
  - Updated Prettier configuration for automatic formatting mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->