### PR TITLE
Workaround for USF and UKF mortar hitpoints

### DIFF
--- a/src/unitStats/workarounds.ts
+++ b/src/unitStats/workarounds.ts
@@ -599,6 +599,47 @@ const setEbpsWorkarounds = () => {
       item.ui.iconName = "races/american/buildings/barracks_us";
     },
   });
+
+  ebpsWorkaround("Modify American - Mortar crew hitpoints", {
+    predicate: (item) => item.faction === "american" && item.id === "crew_mortar_us",
+    mutator: (item) => {
+      item = item as EbpsType;
+      item.health.hitpoints = 80;
+    },
+  });
+
+  ebpsWorkaround("Modify British - Mortar crew hitpoints", {
+    predicate: (item) => item.faction === "british" && item.id === "crew_mortar_uk",
+    mutator: (item) => {
+      item = item as EbpsType;
+      item.health.hitpoints = 80;
+    },
+  });
+
+  ebpsWorkaround("Modify British - Indian Mortar crew hitpoints", {
+    predicate: (item) => item.faction === "british" && item.id === "crew_mortar_indian_uk",
+    mutator: (item) => {
+      item = item as EbpsType;
+      item.health.hitpoints = 80;
+    },
+  });
+
+  ebpsWorkaround("Modify British Africa - Mortar crew hitpoints", {
+    predicate: (item) => item.faction === "british_africa" && item.id === "crew_mortar_africa_uk",
+    mutator: (item) => {
+      item = item as EbpsType;
+      item.health.hitpoints = 80;
+    },
+  });
+
+  ebpsWorkaround("Modify British Africa - Indian Mortar crew hitpoints", {
+    predicate: (item) =>
+      item.faction === "british_africa" && item.id === "crew_mortar_indian_africa_uk",
+    mutator: (item) => {
+      item = item as EbpsType;
+      item.health.hitpoints = 80;
+    },
+  });
 };
 
 setBattlegroupsWorkarounds();


### PR DESCRIPTION
This fixes the mortar missing hitpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized Mortar Crew unit health to 80 across affected factions and subfactions, correcting prior inconsistencies.
  * Ensures consistent survivability and balance for Mortar Crews in all game modes, eliminating outlier durability differences.
  * Improves predictability for players when engaging or fielding Mortar Crews, with no changes to controls or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->