### PR TITLE
fix: Add missing 'stats' translation namespace to achievements page

### DIFF
--- a/pages/stats/achievements.tsx
+++ b/pages/stats/achievements.tsx
@@ -34,7 +34,7 @@ export const getServerSideProps: GetServerSideProps<any, { playerID: string }> =
     props: {
       error,
       globalAchievements,
-      ...(await serverSideTranslations(locale, ["common"])),
+      ...(await serverSideTranslations(locale, ["common", "stats"])),
     },
   };
 };


### PR DESCRIPTION
## Problem
The achievements page at https://coh3stats.com/stats/achievements was displaying `achivements.meta.title` instead of the proper translated title "Achievement Statistics".

## Root Cause
The issue was that the `serverSideTranslations` in `pages/stats/achievements.tsx` was only loading the `"common"` namespace, but the component was trying to use translation keys from the `"stats"` namespace (`stats:achievements.meta.title`).

## Solution
- Added `"stats"` namespace to the `serverSideTranslations` array in `pages/stats/achievements.tsx`
- The translation keys already exist in all language files under `public/locales/*/stats.json`

## Changes
- Modified `pages/stats/achievements.tsx` to include both `"common"` and `"stats"` namespaces

## Testing
- ✅ Build passes successfully
- ✅ Pre-commit hooks (prettier, eslint) pass
- ✅ Translation keys exist in all supported languages

## Files Changed
- `pages/stats/achievements.tsx` - Added missing translation namespace

This is a simple one-line fix that resolves the translation loading issue.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected missing translations on Stats → Achievements by ensuring the “stats” namespace is available during server-side rendering. Users now see fully localized content immediately on first load, without flashes of default language.
  * Improves SEO, social previews, and consistency for localized routes.
  * No functional changes; layout and interactions remain the same, with reduced content flicker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->