### PR TITLE
fix: weapon dps for AT guns

### DIFF
--- a/src/unitStats/dpsCommon.ts
+++ b/src/unitStats/dpsCommon.ts
@@ -105,7 +105,7 @@ type CustomizableUnit = {
   faction: string; // from folder structure races\[factionName]
   weapon_member: WeaponMember[]; // set of weapons + amount
   def_weapon_member: WeaponMember[];
-  unit_type: string; // folder Infantry | vehicles | team_weapons | buildings
+  unit_type: SbpsType["unitType"]; // folder Infantry | vehicles | team_weapons | buildings
   help_text: string; // sbpextensions\squad_ui_ext\race_list\race_data\info\help_text
   icon_name: string; // sbpextensions\squad_ui_ext\race_list\race_data\info\icon_name
   faction_icon: string;
@@ -228,14 +228,13 @@ export const mapCustomizableUnit = (
       custUnit.def_damage_type = (custUnit.weapon_member[0] as any).parent || null;
 
     // Armor
-    const ebpsUnit = ebps.find((unit) => unit.id == custUnit.def_member);
+    const def_ebps = ebps.find((unit) => unit.id == custUnit.def_member);
     custUnit.armor =
-      ebpsUnit?.health.armorLayout?.armor || ebpsUnit?.health.armorLayout?.frontArmor || 1;
+      def_ebps?.health.armorLayout?.armor || def_ebps?.health.armorLayout?.frontArmor || 1;
     if (custUnit.unit_type == "vehicles")
-      custUnit.armor = ebpsUnit?.health.armorLayout.frontArmor || 1;
+      custUnit.armor = def_ebps?.health.armorLayout.frontArmor || 1;
 
     // squad hitpoints
-    const def_ebps = ebps.find((unit) => unit.id == custUnit.def_member);
     if (def_ebps) {
       custUnit.ebps_default = def_ebps;
       custUnit.hitpoints = def_ebps.health.hitpoints;

--- a/src/unitStats/mappingSbps.ts
+++ b/src/unitStats/mappingSbps.ts
@@ -17,7 +17,8 @@ type SbpsType = {
   ui: SquadUiData;
   /** Found at `squad_upgrade_ext.upgrades`. List of instance references. */
   upgrades: string[];
-  unitType: string;
+  /** The parent tag within the source JSON. */
+  unitType: "aircraft" | "emplacements" | "infantry" | "team_weapons" | "vehicles";
   /** The `squad_population_ext` holds the base popcap and upkeep per pop per
    * minute costs, which will be stacked with the ebps. */
   populationExt: {
@@ -104,7 +105,7 @@ const mapSbpsData = (
     screenName: filename,
     path: internalSlash(jsonPath),
     faction: jsonPath.split("/")[1] ?? jsonPath,
-    unitType: parent,
+    unitType: parent as SbpsType["unitType"],
     loadout: [],
     ui: {
       iconName: "",

--- a/src/unitStats/mappingWeapon.ts
+++ b/src/unitStats/mappingWeapon.ts
@@ -326,17 +326,15 @@ const mapWeaponData = (
   };
 
   if (weapon_bag.target_type_table && weapon_bag.target_type_table.length > 0) {
-    for (const targetType of weapon_bag.target_type_table) {
+    for (const { target_unit_type_multipliers } of weapon_bag.target_type_table) {
+      if (!target_unit_type_multipliers) continue;
+      const wm = target_unit_type_multipliers.weapon_multipliers ?? {};
       weaponData.weapon_bag.target_type_table.push({
-        unit_type: targetType.target_unit_type_multipliers?.unit_type || "",
-        dmg_modifier: targetType.target_unit_type_multipliers?.base_damage_modifier || 0,
-        accuracy_multiplier:
-          targetType.target_unit_type_multipliers?.weapon_multipliers?.accuracy_multiplier || 1,
-        penetration_multiplier:
-          targetType.target_unit_type_multipliers?.weapon_multipliers?.penetration_multiplier ||
-          1,
-        damage_multiplier:
-          targetType.target_unit_type_multipliers?.weapon_multipliers?.damage_multiplier || 1,
+        unit_type: target_unit_type_multipliers.unit_type,
+        dmg_modifier: target_unit_type_multipliers.base_damage_modifier ?? 0,
+        accuracy_multiplier: wm.accuracy_multiplier ?? 1,
+        penetration_multiplier: wm.penetration_multiplier ?? 1,
+        damage_multiplier: wm.damage_multiplier ?? 1,
       });
     }
   }

--- a/src/unitStats/mappingWeapon.ts
+++ b/src/unitStats/mappingWeapon.ts
@@ -1,7 +1,7 @@
 import { resolveLocstring } from "./locstring";
 import { traverseTree } from "./unitStatsLib";
 import config from "../../config";
-import { WeaponBagSchema, WeaponCategory, WeaponClass } from "./types";
+import { TargetUnitTypeMultipliers, WeaponBagSchema, WeaponCategory, WeaponClass } from "./types";
 
 const WeaponPatchData: Record<string, Record<string, WeaponType[]>> = {}; // Modified to store by locale and patch
 
@@ -145,7 +145,7 @@ type WeaponType = {
 };
 
 type TargetType = {
-  unit_type: string;
+  unit_type: TargetUnitTypeMultipliers["unit_type"];
   dmg_modifier: number;
   accuracy_multiplier: number;
   penetration_multiplier: number;
@@ -325,20 +325,21 @@ const mapWeaponData = (
     },
   };
 
-  if (weapon_bag.target_type_table)
-    for (const target_types of weapon_bag.target_type_table) {
+  if (weapon_bag.target_type_table && weapon_bag.target_type_table.length > 0) {
+    for (const targetType of weapon_bag.target_type_table) {
       weaponData.weapon_bag.target_type_table.push({
-        unit_type: target_types.target_unit_type_multipliers?.unit_type || "",
-        dmg_modifier: target_types.target_unit_type_multipliers?.base_damage_modifier || 0,
+        unit_type: targetType.target_unit_type_multipliers?.unit_type || "",
+        dmg_modifier: targetType.target_unit_type_multipliers?.base_damage_modifier || 0,
         accuracy_multiplier:
-          target_types.target_unit_type_multipliers?.weapon_multiplier?.accuracy_multiplier || 1,
+          targetType.target_unit_type_multipliers?.weapon_multipliers?.accuracy_multiplier || 1,
         penetration_multiplier:
-          target_types.target_unit_type_multipliers?.weapon_multiplier?.penetration_multiplier ||
+          targetType.target_unit_type_multipliers?.weapon_multipliers?.penetration_multiplier ||
           1,
         damage_multiplier:
-          target_types.target_unit_type_multiplier?.weapon_multipliers?.damage_multiplier || 1,
+          targetType.target_unit_type_multipliers?.weapon_multipliers?.damage_multiplier || 1,
       });
     }
+  }
 
   return weaponData;
 };

--- a/src/unitStats/types.ts
+++ b/src/unitStats/types.ts
@@ -96,7 +96,7 @@ export type WeaponBag = {
   weapon_class: (typeof WeaponClass)[number];
   fx_aoe_munition_name: string;
   speech_code: string;
-  target_type_table: any[];
+  target_type_table: TargetTypeTableItemSchema[];
   cover_table: CoverTable;
   fx_piercing_munition_name: string;
   charge_option: TemplateReferenceParentSchema;
@@ -113,6 +113,23 @@ export type WeaponBag = {
   audio: Audio;
   weapon_impact_modifier: number;
   conditional_table: any[];
+};
+
+type TargetTypeTableItemSchema = {
+  target_unit_type_multipliers: TargetUnitTypeMultipliers;
+};
+
+export type TargetUnitTypeMultipliers = {
+  unit_type: "destructible_object" | "bunker" | "infantry" | "building";
+  weapon_multipliers: WeaponMultipliers;
+  base_damage_modifier: number;
+};
+
+type WeaponMultipliers = {
+  accuracy_multiplier: number;
+  damage_multiplier: number;
+  penetration_multiplier: number;
+  suppression_multiplier: number;
 };
 
 export type Accuracy = {

--- a/src/unitStats/weaponLib.ts
+++ b/src/unitStats/weaponLib.ts
@@ -223,7 +223,7 @@ const getSingleWeaponDPS = (
 
     /** Find the correct `target_unit.unit_type` within the weapons target type
      * list `unit_type`. */
-    const targetUnitTypes = target_unit?.ebps_default.unitTypes || [];
+    const targetUnitTypes = target_unit?.ebps_default?.unitTypes || [];
 
     for (const weaponTargetType of weapon_bag.target_type_table) {
       const foundTargetType = targetUnitTypes.find((ut) => ut === weaponTargetType.unit_type);

--- a/src/unitStats/weaponLib.ts
+++ b/src/unitStats/weaponLib.ts
@@ -223,24 +223,15 @@ const getSingleWeaponDPS = (
 
     /** Find the correct `target_unit.unit_type` within the weapons target type
      * list `unit_type`. */
+    const targetUnitTypes = target_unit?.ebps_default.unitTypes || [];
 
     for (const weaponTargetType of weapon_bag.target_type_table) {
-      if (target_unit) {
-        const foundTargetType = target_unit.ebps_default.unitTypes.find(
-          (ut) => ut === weaponTargetType.unit_type,
-        );
+      const foundTargetType = targetUnitTypes.find((ut) => ut === weaponTargetType.unit_type);
 
-        if (foundTargetType) {
-          target_damage_bonus += weaponTargetType.dmg_modifier;
-          target_damage_mp *= weaponTargetType.damage_multiplier;
-          target_accuracy_mp *= weaponTargetType.accuracy_multiplier;
-
-          // console.group("Weapon Id: ", weapon_member.weapon_id);
-          // console.log("-- Weapon Bag: ", weapon_member.weapon.weapon_bag);
-          // console.log("-- Modifier: ", weaponTargetType);
-          // console.log("-- Target Unit: ", target_unit);
-          // console.groupEnd();
-        }
+      if (foundTargetType) {
+        target_damage_bonus += weaponTargetType.dmg_modifier;
+        target_damage_mp *= weaponTargetType.damage_multiplier;
+        target_accuracy_mp *= weaponTargetType.accuracy_multiplier;
       }
     }
 


### PR DESCRIPTION
I believe this is the correct approach to handle the weapons multipliers per target type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for unit classifications and target tables.
  * Consolidated and standardized armor lookup logic for consistent unit calculations.

* **Bug Fixes / Improvements**
  * More accurate weapon damage and AOE computations using per-target multipliers and bonuses.
  * Added guards to skip empty target data and prevent incorrect multipliers from being applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->