### PR TITLE
Patch 2.3.0

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -30,7 +30,7 @@ const getEdgioEnvName = (): string | null => {
 };
 
 // This controls the default patch selector in the stats page // this needs to be key statsPatchSelector object
-const defaultStatsPatchSelector = "2.2.5";
+const defaultStatsPatchSelector = "2.3.0";
 
 // This controls the patch selector in the stats page
 const statsPatchSelector: Record<
@@ -43,6 +43,13 @@ const statsPatchSelector: Record<
     group: string;
   }
 > = {
+  "2.3.0": {
+    from: "2026-04-01",
+    to: "now",
+    value: "2.3.0",
+    label: "2.3.0",
+    group: "Topaz Rhino",
+  },
   "2.2.5": {
     from: "2026-01-29",
     to: "now",
@@ -228,11 +235,15 @@ const statsPatchSelector: Record<
 };
 
 // Latest patch needs to be a key to patches object
-const latestPatch = "2.2.5";
+const latestPatch = "2.3.0";
 
 // Get patchTimeSeconds here https://www.unixtimestamp.com/
 const patches: Record<string, { dataTag: string; dataTime: string; patchTimeSeconds?: number }> =
   {
+    "2.3.0": {
+      dataTag: "v2.3.0-1",
+      dataTime: "01/Apr/2026",
+    },
     "2.2.5": {
       dataTag: "v2.2.5-1",
       dataTime: "29/Jan/2026",

--- a/config.ts
+++ b/config.ts
@@ -52,7 +52,7 @@ const statsPatchSelector: Record<
   },
   "2.2.5": {
     from: "2026-01-29",
-    to: "now",
+    to: "2026-03-31",
     value: "2.2.5",
     label: "2.2.5",
     group: "Scarlet Bison",

--- a/src/coh3/coh3-data.ts
+++ b/src/coh3/coh3-data.ts
@@ -619,6 +619,11 @@ const OfficialMapKeys = [
   "primosole_6p",
   "oliveto_citra_8p",
   "powderkeg_8p",
+  /* ---------- 2.3.0 Maps ---------- */
+  "egletons_2p",
+  "pisa_centrale_4p",
+  "sedjenane_6p",
+  "castello_8p",
 ] as const;
 
 export function isOfficialMap(mapname: string): mapname is (typeof OfficialMapKeys)[number] {
@@ -881,5 +886,22 @@ export const maps: Record<(typeof OfficialMapKeys)[number], OfficialMapValue> = 
   primosole_6p: {
     name: "Road to Primosole",
     url: "/primosole_6p/primosole_6p.webp",
+  },
+  /* ------------------------- 2.3.0 Maps ---------------------------- */
+  egletons_2p: {
+    name: "Égletons",
+    url: "/egletons_2p/egletons_2p.webp",
+  },
+  pisa_centrale_4p: {
+    name: "Pisa Centrale",
+    url: "/pisa_centrale_4p/pisa_centrale_4p.webp",
+  },
+  sedjenane_6p: {
+    name: "Sedjenane Marshes",
+    url: "/sedjenane_6p/sedjenane_6p.webp",
+  },
+  castello_8p: {
+    name: "Castello della Nebbia",
+    url: "/castello_8p/castello_8p.webp",
   },
 };


### PR DESCRIPTION
Patch 2.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now uses patch 2.3.0 as the default/latest dataset and includes updated statistics coverage.
  * Patch 2.2.5 stats window adjusted to end 2026-03-31.
  * Added four official maps: Égletons (2p), Pisa Centrale (4p), Sedjenane Marshes (6p), and Castello della Nebbia (8p).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->