### PR TITLE
Add Autobounce and Deflection

### DIFF
--- a/components/unit-cards/weapon-loadout-card.tsx
+++ b/components/unit-cards/weapon-loadout-card.tsx
@@ -26,6 +26,7 @@ export const WeaponLoadoutCard = (
   const isValidWeapon =
     weapon_cat == "ballistic_weapon" ||
     weapon_cat == "explosive_weapon" ||
+    weapon_cat == "flame_throwers" ||
     weapon_cat == "small_arms";
   return (
     <Stack gap={8}>
@@ -305,7 +306,7 @@ export const WeaponLoadoutCard = (
           </Grid.Col>
           <Grid.Col span={{ base: 2, md: 2 }}>
             <Text style={{ textAlign: "center" }} c="red.6">
-              {weapon_bag.aoe_outer_radius}
+              {weapon_bag.aoe_width > 0 ? weapon_bag.aoe_width : weapon_bag.aoe_outer_radius}
             </Text>
           </Grid.Col>
         </Grid>

--- a/src/unitStats/mappingWeapon.ts
+++ b/src/unitStats/mappingWeapon.ts
@@ -84,6 +84,9 @@ export type WeaponStatsType = {
 
   default_attack_type: string;
 
+  deflection_damage_multiplier: number;
+  deflection_has_deflection_damage: boolean;
+
   fire_wind_down: number;
   fire_wind_up: number;
 
@@ -276,6 +279,10 @@ const mapWeaponData = (
       damage_max: weapon_bag.damage?.max || 0,
 
       default_attack_type: weapon_bag.default_attack_type || "",
+
+      deflection_damage_multiplier: weapon_bag.deflection?.deflection_damage_multiplier || 0,
+      deflection_has_deflection_damage:
+        weapon_bag.deflection?.has_deflection_damage == "True" ? true : false,
 
       fire_wind_down: weapon_bag.fire?.wind_down || 0,
       fire_wind_up: weapon_bag.fire?.wind_up || 0,

--- a/src/unitStats/mappingWeapon.ts
+++ b/src/unitStats/mappingWeapon.ts
@@ -26,7 +26,10 @@ export type WeaponStatsType = {
   aoe_penetration_mid: number;
   aoe_penetration_near: number;
 
+  aoe_shape: "circle" | "rectangle" | "point" | "unknown";
   aoe_outer_radius: number;
+  aoe_outer_length: number;
+  aoe_width: number;
 
   aoe_damage_far: number;
   aoe_damage_mid: number;
@@ -155,6 +158,18 @@ type TargetType = {
   damage_multiplier: number;
 };
 
+type AoeShape = "point" | "circle" | "rectangle" | "unknown";
+
+const getAoeShape = (templateReference: string | undefined): AoeShape => {
+  const ref = templateReference || "";
+
+  if (ref.includes("point_area_option")) return "point";
+  if (ref.includes("circle_area_option")) return "circle";
+  if (ref.includes("rectangle_area_option")) return "rectangle";
+
+  return "unknown";
+};
+
 const mapWeaponData = (
   key: string,
   node: any,
@@ -215,7 +230,10 @@ const mapWeaponData = (
 
       aoe_damage_max_member: weapon_bag.area_effect?.damage_max_members_per_squad || -1,
 
+      aoe_shape: getAoeShape(weapon_bag.area_effect?.area_info?.template_reference?.value),
       aoe_outer_radius: weapon_bag.area_effect?.area_info?.outer_radius || 0,
+      aoe_outer_length: weapon_bag.area_effect?.area_info?.outer_length || 0,
+      aoe_width: weapon_bag.area_effect?.area_info?.width || 0,
 
       aoe_damage_far: weapon_bag.area_effect?.damage?.far || 1,
       aoe_damage_mid: weapon_bag.area_effect?.damage?.mid || 1,
@@ -338,9 +356,9 @@ const mapWeaponData = (
         unit_type: target_types.target_unit_type_multipliers?.unit_type || "",
         dmg_modifier: target_types.target_unit_type_multipliers?.base_damage_modifier || 0,
         accuracy_multiplier:
-          target_types.target_unit_type_multipliers?.weapon_multiplier?.accuracy_multiplier || 1,
+          target_types.target_unit_type_multipliers?.weapon_multipliers?.accuracy_multiplier || 1,
         penetration_multiplier:
-          target_types.target_unit_type_multipliers?.weapon_multiplier?.penetration_multiplier ||
+          target_types.target_unit_type_multipliers?.weapon_multipliers?.penetration_multiplier ||
           1,
         damage_multiplier:
           target_types.target_unit_type_multipliers?.weapon_multipliers?.damage_multiplier || 1,

--- a/src/unitStats/types.ts
+++ b/src/unitStats/types.ts
@@ -206,10 +206,15 @@ export type AreaEffect = {
 
 export type AreaInfo = {
   template_reference: TemplateReference;
-  outer_radius: number;
-  inner_radius: number;
-  is_two_dimensional: string;
-  dynamic_radius_type: string;
+
+  outer_radius?: number;
+  inner_radius?: number;
+
+  outer_length?: number;
+  width?: number;
+
+  is_two_dimensional?: string;
+  dynamic_radius_type?: string;
 };
 
 export type TemplateReferenceParentSchema = {

--- a/src/unitStats/weaponLib.ts
+++ b/src/unitStats/weaponLib.ts
@@ -332,12 +332,22 @@ const getSingleWeaponDPS = (
   if (attacking_unit?.custom_modifiers?.penetration.enabled !== true) {
     finalPenetrationChance = Math.min(penetration / finalArmor, 1);
   }
-  const finalHitChance = finalAccuracy * finalPenetrationChance;
+  if (finalPenetrationChance < 0.03) {
+    finalPenetrationChance = 0;
+  }
+
+  const penetrationDamageMultiplier =
+    finalPenetrationChance +
+    (weapon_bag.deflection_has_deflection_damage
+      ? weapon_bag.deflection_damage_multiplier * (1 - finalPenetrationChance)
+      : 0);
+
+  const effectiveHitDamageMultiplier = finalAccuracy * penetrationDamageMultiplier;
 
   /*   Damage per Second *
     -------------------------------------------------
   */
-  const dps = (finalRpm / 60) * (finalHitChance * finalDamage);
+  const dps = (finalRpm / 60) * (effectiveHitDamageMultiplier * finalDamage);
 
   return dps * weapon_member.num;
 };

--- a/src/unitStats/weaponLib.ts
+++ b/src/unitStats/weaponLib.ts
@@ -332,7 +332,9 @@ const getSingleWeaponDPS = (
   if (attacking_unit?.custom_modifiers?.penetration.enabled !== true) {
     finalPenetrationChance = Math.min(penetration / finalArmor, 1);
   }
-  if (finalPenetrationChance < 0.03) {
+  //autobounce is at 3%, any pen below that automatically fails
+  const AUTOBOUNCE_THRESHOLD = 0.03;
+  if (finalPenetrationChance < AUTOBOUNCE_THRESHOLD) {
     finalPenetrationChance = 0;
   }
 


### PR DESCRIPTION
Enables the calculation to handle the autobounce (less than 3%, i tested, exactly 3% is enough) and deflection damage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DPS and damage calculations now include deflection mechanics for more accurate combat estimates.
  * Weapon stats expanded to include AOE shape/geometry and explicit deflection properties.
* **User Interface**
  * Weapon loadouts now render flame-thrower categories and prefer AOE width for radius when present.
* **Bug Fixes**
  * Improved target-type multiplier handling and made several AOE fields optional to handle missing data more robustly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cohstats/coh3-stats/pull/905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->