### PR TITLE
Added Add/subtract, new modifier range, multiple percentage entries

### DIFF
--- a/components/unitStats/dps/CustomConfigModal.tsx
+++ b/components/unitStats/dps/CustomConfigModal.tsx
@@ -30,13 +30,59 @@ interface CustomConfigModalProps {
   unitColor?: string;
 }
 
+type PercentStackMode = "normal" | "inverse";
+
+const combinePercentageModifiers = (values: number[], mode: PercentStackMode): number => {
+  const finalMultiplier = values.reduce((current, value) => {
+    const decimal = value / 100;
+    return mode === "inverse" ? current * (1 - decimal) : current * (1 + decimal);
+  }, 1);
+
+  const finalPercent =
+    mode === "inverse" ? (1 - finalMultiplier) * 100 : (finalMultiplier - 1) * 100;
+
+  return finalPercent;
+};
+
 interface StatConfig {
   key: keyof CustomModifiers;
   label: string;
   description: string;
-  baseValue?: number;
   unit: string;
+
+  percentStackMode: PercentStackMode;
+  percentMin: number;
+  percentMax: number;
+  percentStep: number;
+
+  absoluteMin: number;
+  absoluteMax?: number;
+  absoluteStep: number;
+
+  supportsAdditive?: boolean;
+  additiveMin?: number;
+  additiveMax?: number;
+  additiveStep?: number;
 }
+
+const normalPercentConfig = {
+  percentStackMode: "normal" as const,
+  percentMin: -100,
+  percentMax: 500,
+  percentStep: 5,
+};
+
+const inversePercentConfig = {
+  percentStackMode: "inverse" as const,
+  percentMin: -500,
+  percentMax: 100,
+  percentStep: 5,
+};
+
+const defaultAbsoluteConfig = {
+  absoluteMin: 0,
+  absoluteStep: 0.1,
+};
 
 const statConfigs: StatConfig[] = [
   {
@@ -44,62 +90,101 @@ const statConfigs: StatConfig[] = [
     label: "Accuracy",
     description: "Hit chance modifier - affects how often shots connect with targets",
     unit: "%",
+    ...normalPercentConfig,
+    absoluteMin: 0,
+    absoluteStep: 0.05,
   },
   {
     key: "damage",
     label: "Damage",
     description: "Damage per shot modifier - affects raw damage output",
     unit: "dmg",
+    ...normalPercentConfig,
+    ...defaultAbsoluteConfig,
+    supportsAdditive: true,
+    additiveStep: 0.1,
   },
   {
     key: "penetration",
     label: "Penetration",
     description: "Armor penetration modifier - affects damage vs armored targets",
     unit: "pen",
+    ...normalPercentConfig,
+    ...defaultAbsoluteConfig,
   },
   {
     key: "cooldownReload",
     label: "Rate of Fire",
     description:
       "Cooldown and Reload modifier - affects how fast weapons fire, do not add together",
-    unit: "%",
+    unit: "rpm",
+    ...inversePercentConfig,
+    ...defaultAbsoluteConfig,
   },
   {
     key: "overallAttackSpeed",
     label: "Overall Attack Speed",
     description:
       "Time between burst modifier - affects how fast weapons fire, do not add together",
-    unit: "%",
+    unit: "mult",
+    ...inversePercentConfig,
+    ...defaultAbsoluteConfig,
   },
   {
     key: "reload",
     label: "Reload",
     description: "Reload modifier - affects how fast weapons fire, do not add together",
-    unit: "%",
+    unit: "seconds",
+    ...inversePercentConfig,
+    ...defaultAbsoluteConfig,
   },
   {
     key: "burstLength",
     label: "Burst Length",
     description: "Duration of burst - affects how fast weapons fire",
-    unit: "%",
+    unit: "seconds",
+    ...normalPercentConfig,
+    ...defaultAbsoluteConfig,
   },
   {
     key: "burstShots",
     label: "Rounds per Burst",
-    description: "Rounds per minute modifier - affects how fast weapons fire",
-    unit: "%",
+    description: "Rounds per burst modifier - affects how many shots are fired per burst",
+    unit: "shots",
+    ...normalPercentConfig,
+    ...defaultAbsoluteConfig,
+  },
+  {
+    key: "range",
+    label: "Range",
+    description: "Weapon range modifier - affects how far weapons can fire",
+    unit: "range",
+    ...normalPercentConfig,
+    absoluteMin: 0,
+    absoluteStep: 1,
+    supportsAdditive: true,
+    additiveStep: 1,
   },
   {
     key: "armor",
     label: "Armor",
     description: "Target armor value - affects penetration calculations and damage reduction",
     unit: "armor",
+    ...normalPercentConfig,
+    ...defaultAbsoluteConfig,
+    supportsAdditive: true,
+    additiveStep: 0.1,
   },
   {
     key: "hitpoints",
     label: "Hit Points",
-    description: "Unit health modifier - affects how much damage the unit can take before dying",
+    description: "Unit health value - affects how much damage the unit can take before dying",
     unit: "HP",
+    ...normalPercentConfig,
+    absoluteMin: 0,
+    absoluteStep: 5,
+    supportsAdditive: true,
+    additiveStep: 5,
   },
 ];
 
@@ -146,6 +231,7 @@ export const CustomConfigModal: React.FC<CustomConfigModalProps> = ({
       overallAttackSpeed: { type: "percentage", value: 0, enabled: false },
       burstLength: { type: "percentage", value: 0, enabled: false },
       burstShots: { type: "percentage", value: 0, enabled: false },
+      range: { type: "percentage", value: 0, enabled: false },
       armor: { type: "percentage", value: 0, enabled: false },
       hitpoints: { type: "percentage", value: 0, enabled: false },
     };
@@ -153,12 +239,84 @@ export const CustomConfigModal: React.FC<CustomConfigModalProps> = ({
     onModifiersChange(resetModifiers);
   };
 
-  const getDisplayValue = (modifier: CustomModifier) => {
+  const getDisplayValue = (modifier: CustomModifier, config: StatConfig) => {
     if (!modifier.enabled) return "Default";
+
     if (modifier.type === "percentage") {
-      return `${modifier.value > 0 ? "+" : ""}${modifier.value}%`;
+      const percentageValues = getPercentageValues(modifier);
+      const collapsedValue = combinePercentageModifiers(
+        percentageValues,
+        config.percentStackMode,
+      );
+
+      return `${collapsedValue >= 0 ? "+" : ""}${Math.round(collapsedValue * 100) / 100}%`;
     }
+
+    if (modifier.type === "additive") {
+      return `${modifier.value >= 0 ? "+" : ""}${modifier.value}`;
+    }
+
     return `${modifier.value}`;
+  };
+
+  const getPercentageValues = (modifier: CustomModifier): number[] => {
+    if (Array.isArray(modifier.percentageValues)) {
+      return modifier.percentageValues;
+    }
+
+    // Backwards compatibility with old saved/current modifiers.
+    if (modifier.type === "percentage" && modifier.value !== 0) {
+      return [modifier.value];
+    }
+
+    return [];
+  };
+
+  const patchModifier = (statKey: keyof CustomModifiers, patch: Partial<CustomModifier>) => {
+    const newModifiers = {
+      ...localModifiers,
+      [statKey]: {
+        ...localModifiers[statKey],
+        ...patch,
+      },
+    };
+
+    setLocalModifiers(newModifiers);
+    onModifiersChange(newModifiers);
+  };
+
+  const handlePercentageEntryChange = (
+    config: StatConfig,
+    index: number,
+    rawValue: string | number,
+  ) => {
+    const modifier = localModifiers[config.key];
+    const currentValues = getPercentageValues(modifier);
+    const nextValues = [...currentValues];
+
+    // Emptying an existing box removes that entry.
+    if (rawValue === "") {
+      nextValues.splice(index, 1);
+    } else if (typeof rawValue === "number" && Number.isFinite(rawValue)) {
+      nextValues[index] = rawValue;
+    } else {
+      return;
+    }
+
+    const collapsedValue = combinePercentageModifiers(nextValues, config.percentStackMode);
+
+    patchModifier(config.key, {
+      percentageValues: nextValues,
+      value: collapsedValue,
+    });
+  };
+
+  const handleTypeChange = (config: StatConfig, type: CustomModifierType) => {
+    patchModifier(config.key, {
+      type,
+      value: 0,
+      percentageValues: type === "percentage" ? [] : undefined,
+    });
   };
 
   const getValueColor = (modifier: CustomModifier) => {
@@ -196,6 +354,7 @@ export const CustomConfigModal: React.FC<CustomConfigModalProps> = ({
 
         {statConfigs.map((config) => {
           const modifier = localModifiers[config.key];
+          const percentageValues = getPercentageValues(modifier);
           return (
             <Card key={config.key} p="sm" withBorder>
               <Grid align="center">
@@ -212,7 +371,7 @@ export const CustomConfigModal: React.FC<CustomConfigModalProps> = ({
                 <Grid.Col span={{ base: 6, sm: 3 }}>
                   <Group gap="xs" align="center" justify="flex-end">
                     <Badge size="md" variant="light" color={getValueColor(modifier)}>
-                      {getDisplayValue(modifier)}
+                      {getDisplayValue(modifier, config)}
                     </Badge>
                     <Tooltip label={modifier.enabled ? "Disable modifier" : "Enable modifier"}>
                       <Switch
@@ -230,12 +389,13 @@ export const CustomConfigModal: React.FC<CustomConfigModalProps> = ({
                 <Grid.Col span={{ base: 6, sm: 3 }}>
                   <Select
                     value={modifier.type}
-                    onChange={(value) =>
-                      handleModifierChange(config.key, "type", value as CustomModifierType)
-                    }
+                    onChange={(value) => handleTypeChange(config, value as CustomModifierType)}
                     data={[
                       { value: "percentage", label: "Percentage" },
                       { value: "absolute", label: "Absolute" },
+                      ...(config.supportsAdditive
+                        ? [{ value: "additive", label: "Add/Subtract" }]
+                        : []),
                     ]}
                     disabled={!modifier.enabled}
                     size="sm"
@@ -245,17 +405,73 @@ export const CustomConfigModal: React.FC<CustomConfigModalProps> = ({
 
                 {/* Second row on mobile: Number Input */}
                 <Grid.Col span={{ base: 6, sm: 3 }}>
-                  <NumberInput
-                    value={modifier.value}
-                    onChange={(value) => handleModifierChange(config.key, "value", value || 0)}
-                    disabled={!modifier.enabled}
-                    placeholder={modifier.type === "percentage" ? "±%" : config.unit}
-                    size="sm"
-                    step={modifier.type === "percentage" ? 5 : 0.1}
-                    min={modifier.type === "percentage" ? -100 : 0}
-                    max={modifier.type === "percentage" ? 500 : undefined}
-                    w={{ base: "100%", sm: 80 }}
-                  />
+                  {modifier.type === "percentage" ? (
+                    <Group
+                      gap={4}
+                      wrap="nowrap"
+                      style={{
+                        overflowX: "auto",
+                        maxWidth: "100%",
+                        paddingBottom: 4,
+                      }}
+                    >
+                      {[...percentageValues, undefined].map((entryValue, index) => (
+                        <NumberInput
+                          key={index}
+                          value={entryValue ?? ""}
+                          onChange={(value) => handlePercentageEntryChange(config, index, value)}
+                          disabled={!modifier.enabled}
+                          placeholder={index === percentageValues.length ? "+%" : "±%"}
+                          size="sm"
+                          step={config.percentStep}
+                          min={config.percentMin}
+                          max={config.percentMax}
+                          hideControls
+                          w={48}
+                          styles={{
+                            root: {
+                              flex: "0 0 36px",
+                            },
+                            input: {
+                              paddingInline: 1,
+                              textAlign: "center",
+                              height: 28,
+                              minHeight: 28,
+                              fontSize: 12,
+                            },
+                          }}
+                        />
+                      ))}
+                    </Group>
+                  ) : (
+                    <NumberInput
+                      value={modifier.value}
+                      onChange={(value) =>
+                        handleModifierChange(
+                          config.key,
+                          "value",
+                          typeof value === "number" ? value : 0,
+                        )
+                      }
+                      disabled={!modifier.enabled}
+                      placeholder={
+                        modifier.type === "additive" ? `± ${config.unit}` : config.unit
+                      }
+                      size="sm"
+                      step={
+                        modifier.type === "additive"
+                          ? (config.additiveStep ?? config.absoluteStep)
+                          : config.absoluteStep
+                      }
+                      min={modifier.type === "additive" ? config.additiveMin : config.absoluteMin}
+                      max={
+                        modifier.type === "additive"
+                          ? config.additiveMax
+                          : (config.absoluteMax ?? undefined)
+                      }
+                      w={{ base: "100%", sm: 80 }}
+                    />
+                  )}
                 </Grid.Col>
               </Grid>
             </Card>

--- a/src/unitStats/dpsCommon.ts
+++ b/src/unitStats/dpsCommon.ts
@@ -4,7 +4,7 @@ import { SbpsType } from "./mappingSbps";
 import { WeaponStatsType, WeaponType } from "./mappingWeapon";
 import { getSquadTotalCost, getSquadTotalUpkeepCost } from "./squadTotalCost";
 import { getFactionIcon } from "./unitStatsLib";
-import { getSingleWeaponDPS } from "./weaponLib";
+import { getSingleWeaponDPS, applyCustomModifier } from "./weaponLib";
 
 type CoordinatesDPS = { x: number; y: number };
 
@@ -81,12 +81,15 @@ export const mapWeaponMember = (
   return member;
 };
 
-type CustomModifierType = "percentage" | "absolute";
+type CustomModifierType = "percentage" | "absolute" | "additive";
 
 type CustomModifier = {
   type: CustomModifierType;
   value: number;
   enabled: boolean;
+
+  // UI-only: individual percentage entries
+  percentageValues?: number[];
 };
 
 type CustomModifiers = {
@@ -98,6 +101,7 @@ type CustomModifiers = {
   overallAttackSpeed: CustomModifier;
   burstLength: CustomModifier;
   burstShots: CustomModifier;
+  range: CustomModifier;
   armor: CustomModifier;
   hitpoints: CustomModifier;
 };
@@ -155,6 +159,7 @@ export const createDefaultCustomModifiers = (): CustomModifiers => ({
   overallAttackSpeed: { type: "percentage", value: 0, enabled: false },
   burstLength: { type: "percentage", value: 0, enabled: false },
   burstShots: { type: "percentage", value: 0, enabled: false },
+  range: { type: "percentage", value: 0, enabled: false },
   armor: { type: "percentage", value: 0, enabled: false },
   hitpoints: { type: "percentage", value: 0, enabled: false },
 });
@@ -476,16 +481,23 @@ export const getCompareDpsData = (
 
 // Helper function to get modified hitpoints per entity
 export const getModifiedHitpoints = (unit: CustomizableUnit): number => {
-  let modifiedHitpoints = unit.hitpoints;
-  if (unit.custom_modifiers?.hitpoints.enabled) {
-    if (unit.custom_modifiers.hitpoints.type === "percentage") {
-      modifiedHitpoints = unit.hitpoints * (1 + unit.custom_modifiers.hitpoints.value / 100);
-    } else {
-      modifiedHitpoints = unit.custom_modifiers.hitpoints.value;
-    }
-    modifiedHitpoints = Math.max(modifiedHitpoints, 1); // Ensure minimum 1 HP
+  const modifier = unit.custom_modifiers?.hitpoints;
+
+  if (!modifier?.enabled) {
+    return Math.max(unit.hitpoints, 1);
   }
-  return modifiedHitpoints;
+
+  let modifiedHitpoints = unit.hitpoints;
+
+  if (modifier.type === "percentage") {
+    modifiedHitpoints = unit.hitpoints * (1 + modifier.value / 100);
+  } else if (modifier.type === "absolute") {
+    modifiedHitpoints = modifier.value;
+  } else if (modifier.type === "additive") {
+    modifiedHitpoints = unit.hitpoints + modifier.value;
+  }
+
+  return Math.max(modifiedHitpoints, 1);
 };
 
 export const updateHealth = (unit: CustomizableUnit) => {
@@ -502,6 +514,57 @@ export const updateHealth = (unit: CustomizableUnit) => {
     health += modifiedHitpoints;
   }
   unit.health = health;
+};
+
+const getUnitBaseMaxRange = (unit: CustomizableUnit): number => {
+  return unit.weapon_member.reduce((maxRange, ldout) => {
+    return Math.max(maxRange, ldout.weapon.weapon_bag.range_max ?? 0);
+  }, 0);
+};
+
+const getUnitModifiedRangeInfo = (unit: CustomizableUnit) => {
+  const baseMaxRange = getUnitBaseMaxRange(unit);
+
+  if (baseMaxRange <= 0) {
+    return {
+      baseMaxRange: 0,
+      modifiedMaxRange: 0,
+      rangeScale: 1,
+    };
+  }
+
+  const modifiedMaxRange = applyCustomModifier(baseMaxRange, unit.custom_modifiers?.range, {
+    percentMode: "normal",
+    min: 1,
+  });
+
+  return {
+    baseMaxRange,
+    modifiedMaxRange,
+    rangeScale: modifiedMaxRange / baseMaxRange,
+  };
+};
+
+const getUnitDpsAtBaseDistance = (
+  baseDistance: number,
+  unit1: CustomizableUnit,
+  unit2?: CustomizableUnit,
+): number => {
+  let totalDps = 0;
+
+  unit1.weapon_member.forEach((ldout) => {
+    const weapon_member = ldout;
+    const range_min = weapon_member.weapon.weapon_bag.range_min;
+    const range_max = weapon_member.weapon.weapon_bag.range_max;
+
+    if (baseDistance < range_min || baseDistance > range_max) {
+      return;
+    }
+
+    totalDps += getSingleWeaponDPS(weapon_member, baseDistance, unit1.is_moving, unit2, unit1);
+  });
+
+  return totalDps;
 };
 
 export const getDpsVsHealth = (
@@ -521,51 +584,32 @@ export const getDpsVsHealth = (
 };
 
 export const getCombatDps = (unit1: CustomizableUnit, unit2?: CustomizableUnit) => {
-  // compute dps for first squad
-  let dpsTotal: CoordinatesDPS[] = [];
+  const dpsTotal: CoordinatesDPS[] = [];
 
-  // compute total dps for complete loadout
-  unit1.weapon_member.forEach((ldout) => {
-    const weapon_member = ldout;
-    const weaponDps = [];
+  const { modifiedMaxRange, rangeScale } = getUnitModifiedRangeInfo(unit1);
 
-    const range_min = weapon_member.weapon.weapon_bag.range_min;
-    const range_max = weapon_member.weapon.weapon_bag.range_max;
-    // opponent default values
+  for (let displayedDistance = 0; displayedDistance <= modifiedMaxRange; displayedDistance++) {
+    const baseDistance = displayedDistance / rangeScale;
 
-    for (let distance = range_min; distance <= range_max; distance++) {
-      const dps = getSingleWeaponDPS(weapon_member, distance, unit1.is_moving, unit2, unit1);
-      weaponDps.push({ x: distance, y: dps });
-    }
+    const dps = getUnitDpsAtBaseDistance(baseDistance, unit1, unit2);
 
-    dpsTotal = addDpsData(dpsTotal, weaponDps);
-  });
+    dpsTotal.push({
+      x: displayedDistance,
+      y: dps,
+    });
+  }
 
   return dpsTotal;
 };
 
 const getDpsByDistance = (distance = 0, unit1: CustomizableUnit, unit2?: CustomizableUnit) => {
-  // compute dps for first squad
-  let dpsTotal: CoordinatesDPS[] = [];
+  const { rangeScale } = getUnitModifiedRangeInfo(unit1);
 
-  // compute total dps for complete loadout
-  unit1.weapon_member.forEach((ldout) => {
-    const weapon_member = ldout;
-    const weaponDps = [];
+  const baseDistance = distance / rangeScale;
 
-    // const range_min = weapon_member.weapon.weapon_bag.range_min;
-    // const range_max = weapon_member.weapon.weapon_bag.range_max;
-    // opponent default values
+  const dps = getUnitDpsAtBaseDistance(baseDistance, unit1, unit2);
 
-    // for (let distance = range_min; distance <= range_max; distance++) {
-    const dps = getSingleWeaponDPS(weapon_member, distance, unit1.is_moving, unit2, unit1);
-    weaponDps.push({ x: distance, y: dps });
-    // }
-
-    dpsTotal = addDpsData(dpsTotal, weaponDps);
-  });
-
-  return Math.floor(dpsTotal[0]?.y || 0);
+  return Math.floor(dps);
 };
 
 // sums up two dps lines

--- a/src/unitStats/weaponLib.ts
+++ b/src/unitStats/weaponLib.ts
@@ -1,8 +1,58 @@
-import { CustomizableUnit, getCoverMultiplier, WeaponMember } from "./dpsCommon";
+import { CustomizableUnit, getCoverMultiplier, WeaponMember, CustomModifier } from "./dpsCommon";
 import { RangeType, WeaponStatsType } from "./mappingWeapon";
 
 const TICK_DURATION = 0.125;
 const tickRate = 1 / TICK_DURATION;
+
+type PercentApplyMode = "normal" | "inverse";
+
+interface ApplyCustomModifierOptions {
+  percentMode?: PercentApplyMode;
+  min?: number;
+  max?: number;
+}
+
+export const applyCustomModifier = (
+  baseValue: number,
+  modifier: CustomModifier | undefined,
+  options: ApplyCustomModifierOptions = {},
+): number => {
+  if (!modifier?.enabled) return baseValue;
+
+  const value = Number.isFinite(modifier.value) ? modifier.value : 0;
+  const percentMode = options.percentMode ?? "normal";
+
+  let result = baseValue;
+
+  switch (modifier.type) {
+    case "percentage":
+      result =
+        percentMode === "inverse" ? baseValue * (1 - value / 100) : baseValue * (1 + value / 100);
+      break;
+
+    case "absolute":
+      result = value;
+      break;
+
+    case "additive":
+      result = baseValue + value;
+      break;
+
+    default:
+      result = baseValue;
+      break;
+  }
+
+  if (options.min !== undefined) {
+    result = Math.max(options.min, result);
+  }
+
+  if (options.max !== undefined) {
+    result = Math.min(options.max, result);
+  }
+
+  return result;
+};
 
 const getSingleWeaponDPS = (
   weapon_member: WeaponMember,
@@ -57,14 +107,10 @@ const getSingleWeaponDPS = (
     armor = target_unit.armor;
 
     // Apply armor modifier from target unit early (affects all armor calculations)
-    if (target_unit.custom_modifiers?.armor.enabled) {
-      if (target_unit.custom_modifiers.armor.type === "percentage") {
-        armor = armor * (1 + target_unit.custom_modifiers.armor.value / 100);
-      } else {
-        armor = target_unit.custom_modifiers.armor.value;
-      }
-      armor = Math.max(armor, 0.1); // Ensure positive (minimum 0.1 to avoid division by zero)
-    }
+    armor = applyCustomModifier(armor, target_unit.custom_modifiers?.armor, {
+      percentMode: "normal",
+      min: 0,
+    });
   }
 
   const range: RangeType = {
@@ -293,14 +339,10 @@ const getSingleWeaponDPS = (
     }
 
     // Apply damage modifier
-    if (modifiers.damage.enabled) {
-      if (modifiers.damage.type === "percentage") {
-        finalDamage = finalDamage * (1 + modifiers.damage.value / 100);
-      } else {
-        finalDamage = modifiers.damage.value;
-      }
-      finalDamage = Math.max(finalDamage, 0); // Ensure non-negative
-    }
+    finalDamage = applyCustomModifier(finalDamage, modifiers?.damage, {
+      percentMode: "normal",
+      min: 0,
+    });
 
     // Apply penetration modifier
     if (modifiers.penetration.enabled) {


### PR DESCRIPTION
New custom modifier range added.
Armour, HP and Range support add/subtract now (requested by users).
Custom modifiers now support multiple percentage modifiers, so one can type in +20% and +15%, including handling our inverse modifiers that stack weirdly. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Custom modifiers now support additive mode for hitpoints, enabling more flexible stat adjustments
  * Range scaling can be configured and customized via modifier settings
  * Enhanced modifier editor with advanced percentage stacking modes supporting normal and inverse composition
  * Multi-entry configuration for complex modifier combinations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cohstats/coh3-stats/pull/909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->