### PR TITLE
Changed Aim time to include wind up when available, dps graph scaling based on active weapons, some mapping fixes/additions

### DIFF
--- a/components/unit-cards/unit-upgrade-card.tsx
+++ b/components/unit-cards/unit-upgrade-card.tsx
@@ -284,9 +284,11 @@ export const ConstructableCard = ({ desc, time_cost, cfg }: UnitUpgrade) => {
 };
 
 /** Only for the buildable list. */
-const hasBuildableCost = (time_cost: ResourceValues) => {
+const hasBuildableCost = (time_cost: ResourceValues & { time?: number }) => {
   const hasMan = time_cost?.manpower && time_cost.manpower > 0;
   const hasFuel = time_cost?.fuel && time_cost.fuel > 0;
   const hasAmmo = time_cost?.munition && time_cost.munition > 0;
-  return hasMan || hasFuel || hasAmmo;
+  const hasTime = time_cost?.time && time_cost.time > 0;
+
+  return hasMan || hasFuel || hasAmmo || hasTime;
 };

--- a/components/unit-cards/weapon-loadout-card.tsx
+++ b/components/unit-cards/weapon-loadout-card.tsx
@@ -757,6 +757,21 @@ export const WeaponLoadoutCard = (
   const rpmMid = roundValue(timingMid.rpm);
   const rpmFar = roundValue(timingFar.rpm);
 
+  
+  const readyAimMin = weapon_bag.ready_aim_time_min ?? 0;
+  const readyAimMax = weapon_bag.ready_aim_time_max ?? 0;
+  const baseWindUp = weapon_bag.fire_wind_up ?? 0;
+  const windUp = baseWindUp > 0 ? baseWindUp + 0.125 : 0;
+  const hasAimTime = readyAimMin > 0 || readyAimMax > 0;
+  const hasWindUp = windUp > 0;
+  const aimAndWindUpLabel =
+    hasAimTime && hasWindUp
+      ? t("weaponCard.aimTimeWithWindUp")
+      : hasWindUp
+        ? t("weaponCard.windUp")
+        : t("weaponCard.aimTime");
+
+
   const hasReloadFrequency =
     weapon_bag.reload_frequency_min !== 0 || weapon_bag.reload_frequency_max !== 0;
 
@@ -1393,12 +1408,12 @@ export const WeaponLoadoutCard = (
             {
               icon: WeaponCardIcons["aim_time"],
               alt: "weapon aim time",
-              label: t("weaponCard.aimTime"),
+              label: aimAndWindUpLabel,
               value: formatMinMaxSeconds(
-                Math.round(weapon_bag.ready_aim_time_min * 8) / 8,
-                Math.round(weapon_bag.ready_aim_time_max * 8) / 8,
+                Math.round((readyAimMin + windUp) * 8) / 8,
+                Math.round((readyAimMax + windUp) * 8) / 8,
               ),
-              show: weapon_bag.ready_aim_time_min > 0 || weapon_bag.ready_aim_time_max > 0,
+              show: hasAimTime || hasWindUp,
             },
             {
               icon: WeaponCardIcons["reload_frequency"],

--- a/components/unit-cards/weapon-loadout-card.tsx
+++ b/components/unit-cards/weapon-loadout-card.tsx
@@ -757,7 +757,6 @@ export const WeaponLoadoutCard = (
   const rpmMid = roundValue(timingMid.rpm);
   const rpmFar = roundValue(timingFar.rpm);
 
-  
   const readyAimMin = weapon_bag.ready_aim_time_min ?? 0;
   const readyAimMax = weapon_bag.ready_aim_time_max ?? 0;
   const baseWindUp = weapon_bag.fire_wind_up ?? 0;
@@ -770,7 +769,6 @@ export const WeaponLoadoutCard = (
       : hasWindUp
         ? t("weaponCard.windUp")
         : t("weaponCard.aimTime");
-
 
   const hasReloadFrequency =
     weapon_bag.reload_frequency_min !== 0 || weapon_bag.reload_frequency_max !== 0;

--- a/components/unit-cards/weapon-loadout-card.tsx
+++ b/components/unit-cards/weapon-loadout-card.tsx
@@ -11,7 +11,7 @@ import {
 } from "@mantine/core";
 import { getScatterDimensions, getWeaponRpm, WeaponStatsType } from "../../src/unitStats";
 import { getDefaultWeaponIcon } from "../../src/unitStats/dpsCommon";
-import { getWeaponTiming } from "../../src/unitStats/weaponLib";
+import { getWeaponTiming, TICK_DURATION } from "../../src/unitStats/weaponLib";
 import ImageWithFallback, { symbolPlaceholder } from "../placeholders";
 import { useTranslation } from "next-i18next";
 import HelperIcon from "../icon/helper";
@@ -757,10 +757,13 @@ export const WeaponLoadoutCard = (
   const rpmMid = roundValue(timingMid.rpm);
   const rpmFar = roundValue(timingFar.rpm);
 
-  const readyAimMin = weapon_bag.ready_aim_time_min ?? 0;
-  const readyAimMax = weapon_bag.ready_aim_time_max ?? 0;
+  const readyAimMin =
+    Math.round((weapon_bag.ready_aim_time_min ?? 0) / TICK_DURATION) * TICK_DURATION; //these are rounded to the nearest tick
+  const readyAimMax =
+    Math.round((weapon_bag.ready_aim_time_max ?? 0) / TICK_DURATION) * TICK_DURATION;
   const baseWindUp = weapon_bag.fire_wind_up ?? 0;
-  const windUp = baseWindUp > 0 ? baseWindUp + 0.125 : 0;
+  const windUp =
+    baseWindUp > 0 ? Math.round((baseWindUp + TICK_DURATION) / TICK_DURATION) * TICK_DURATION : 0;
   const hasAimTime = readyAimMin > 0 || readyAimMax > 0;
   const hasWindUp = windUp > 0;
   const aimAndWindUpLabel =
@@ -1407,10 +1410,7 @@ export const WeaponLoadoutCard = (
               icon: WeaponCardIcons["aim_time"],
               alt: "weapon aim time",
               label: aimAndWindUpLabel,
-              value: formatMinMaxSeconds(
-                Math.round((readyAimMin + windUp) * 8) / 8,
-                Math.round((readyAimMax + windUp) * 8) / 8,
-              ),
+              value: formatMinMaxSeconds(readyAimMin + windUp, readyAimMax + windUp),
               show: hasAimTime || hasWindUp,
             },
             {

--- a/public/locales/en/explorer.json
+++ b/public/locales/en/explorer.json
@@ -138,6 +138,8 @@
     "scatterAngle": "Scatter Angle",
     "scatterDistance": "Scatter Distance",
     "aimTime": "Aim Time",
+    "aimTimeWithWindUp": "Pre-Fire Time",
+    "windUp": "Wind Up",
     "scatterOffset": "Scatter Offset",
     "reloadFrequency": "Magazine",
     "bursts": "bursts",

--- a/src/unitStats/dpsCommon.ts
+++ b/src/unitStats/dpsCommon.ts
@@ -433,10 +433,16 @@ const findEbpsByReference = (ebpsList: EbpsType[], reference: unknown) => {
 const ALWAYS_INCLUDE_OPTIONAL_ABILITY_WEAPON_IDS = new Set(["weapon_crate_ranger_us"]);
 
 const isOptionalDpsAbilityWeapon = (ability: AbilitiesType) => {
+  const hasValidNumShots =
+    typeof ability.numShots === "number" &&
+    Number.isInteger(ability.numShots) &&
+    ability.numShots > 0;
+
   return (
-    ability.activation === "timed" ||
-    ability.activation === "toggle" ||
-    ALWAYS_INCLUDE_OPTIONAL_ABILITY_WEAPON_IDS.has(ability.id)
+    !hasValidNumShots &&
+    (ability.activation === "timed" ||
+      ability.activation === "toggle" ||
+      ALWAYS_INCLUDE_OPTIONAL_ABILITY_WEAPON_IDS.has(ability.id))
   );
 };
 
@@ -1129,6 +1135,8 @@ export const updateHealth = (unit: CustomizableUnit) => {
 
 const getUnitBaseMaxRange = (unit: CustomizableUnit): number => {
   return unit.weapon_member.reduce((maxRange, ldout) => {
+    if (ldout.num <= 0) return maxRange;
+
     return Math.max(maxRange, ldout.weapon.weapon_bag.range_max ?? 0);
   }, 0);
 };
@@ -1165,6 +1173,11 @@ const getUnitDpsAtBaseDistance = (
 
   unit1.weapon_member.forEach((ldout) => {
     const weapon_member = ldout;
+
+    if (weapon_member.num <= 0) {
+      return;
+    }
+
     const range_min = weapon_member.weapon.weapon_bag.range_min;
     const range_max = weapon_member.weapon.weapon_bag.range_max;
 

--- a/src/unitStats/dpsCommon.ts
+++ b/src/unitStats/dpsCommon.ts
@@ -433,17 +433,16 @@ const findEbpsByReference = (ebpsList: EbpsType[], reference: unknown) => {
 const ALWAYS_INCLUDE_OPTIONAL_ABILITY_WEAPON_IDS = new Set(["weapon_crate_ranger_us"]);
 
 const isOptionalDpsAbilityWeapon = (ability: AbilitiesType) => {
+  if (ALWAYS_INCLUDE_OPTIONAL_ABILITY_WEAPON_IDS.has(ability.id)) {
+    return true;
+  }
+
   const hasValidNumShots =
     typeof ability.numShots === "number" &&
     Number.isInteger(ability.numShots) &&
     ability.numShots > 0;
 
-  return (
-    !hasValidNumShots &&
-    (ability.activation === "timed" ||
-      ability.activation === "toggle" ||
-      ALWAYS_INCLUDE_OPTIONAL_ABILITY_WEAPON_IDS.has(ability.id))
-  );
+  return !hasValidNumShots && (ability.activation === "timed" || ability.activation === "toggle");
 };
 
 const findAbilityByReference = (abilities: AbilitiesType[], reference: unknown) => {

--- a/src/unitStats/weaponLib.ts
+++ b/src/unitStats/weaponLib.ts
@@ -1,7 +1,7 @@
 import { CustomizableUnit, getCoverMultiplier, WeaponMember, CustomModifier } from "./dpsCommon";
 import { RangeType, WeaponStatsType } from "./mappingWeapon";
 
-const TICK_DURATION = 0.125;
+export const TICK_DURATION = 0.125;
 const tickRate = 1 / TICK_DURATION;
 
 type PercentApplyMode = "normal" | "inverse";

--- a/src/unitStats/workarounds.ts
+++ b/src/unitStats/workarounds.ts
@@ -511,15 +511,6 @@ export const getUpgradeStateTreeWeapons = (stateTree?: string): UpgradeStateTree
   return UpgradeStateTreeToWeaponMap[stateTree] ?? [];
 };
 
-// spawn upgrade state tree map
-export const StateTreeToSpawnUpgradeMap: Record<string, string | string[]> = {
-  panzerjaeger_weapon_spawn: "panzerbuchse_panzerpioneer_ak",
-  add_bazooka_bazooka_team_us: "bazooka_bazooka_team_us",
-  toggle_lmg_bazooka_ssf_spawn: "m1941_lmg_special_operations_us",
-  spawn_equip_lmg_commando_uk: "upgrade/german/infantry/mg42_stormtrooper_ger",
-  add_lmg_stormtrooper_ger: "mg42_stormtrooper_ger",
-};
-
 export type StateTreeSpawnWeapon = {
   pbg: string;
   count?: number;
@@ -552,6 +543,15 @@ export const StateTreeToSpawnMap: Record<string, StateTreeSpawnMapping> = {
       {
         pbg: "ebps/races/british/weapons/small_arms/machine_guns/light_machine_gun/w_vickers_k_lmg_uk",
         count: 1,
+        replacesNormalWeapon: true,
+      },
+    ],
+  },
+  add_bazooka_guards_uk: {
+    weapons: [
+      {
+        pbg: "bazooka_guards_africa_uk",
+        count: 2,
         replacesNormalWeapon: true,
       },
     ],
@@ -1032,14 +1032,14 @@ export const AbilityStateTreeWeaponMappings: AbilityStateTreeWeaponMapping[] = [
     weaponIds: ["95mm_hesh_round_centaur_uk"],
   },
   {
-    abilityId: "sabot_sherman_firefly_africa_uk",
+    abilityId: "polish_cavalry_tulip_rocket_strike_sherman_firefly_africa_uk",
     stateTreePath: [
       "ability_bag",
       "ability_active_state_tree_group",
       "ability_activate_entity_tree",
     ],
-    stateTree: "equip_and_fire_weapon",
-    weaponIds: ["17pdr_firefly_sabot_uk"],
+    stateTree: "rotate_and_fire_coax_weapon_salvo",
+    weaponIds: ["tulip_rocket_coaxial_firefly_uk", "tulip_rocket_coaxial_firefly_panzerbane_uk"],
     numShots: 1,
   },
   {
@@ -1064,6 +1064,18 @@ export const AbilityStateTreeWeaponMappings: AbilityStateTreeWeaponMapping[] = [
     ],
     stateTree: "smoke_barrage_humber",
     weaponIds: ["2inch_mortar_smoke_humber_uk"],
+  },
+  {
+    abilityId: "s_mine_launcher_grinding_advance_ger",
+    stateTreePath: ["ability_bag", "global_tree"],
+    stateTree: "s_mine_launcher_tiger_ak\\grinding_advance_launchers\\root",
+    numShots: 1,
+  },
+  {
+    abilityId: "s_mine_launcher_grinding_advance_32_ger",
+    stateTreePath: ["ability_bag", "global_tree"],
+    stateTree: "s_mine_launcher_tiger_ak\\grinding_advance_launchers\\root",
+    numShots: 1,
   },
   {
     abilityId: "sniper_pinning_shot_ger",

--- a/src/unitStats/workarounds.ts
+++ b/src/unitStats/workarounds.ts
@@ -550,7 +550,7 @@ export const StateTreeToSpawnMap: Record<string, StateTreeSpawnMapping> = {
   add_bazooka_guards_uk: {
     weapons: [
       {
-        pbg: "bazooka_guards_africa_uk",
+        pbg: "ebps/races/american/weapons/ballistic_weapon/infantry_anti_tank_weapon/w_bazooka_guards_africa_uk",
         count: 2,
         replacesNormalWeapon: true,
       },

--- a/src/unitStats/workarounds.ts
+++ b/src/unitStats/workarounds.ts
@@ -793,6 +793,16 @@ export const AbilityStateTreeWeaponMappings: AbilityStateTreeWeaponMapping[] = [
     numShots: 8,
   },
   {
+    abilityId: "veterancy_1a_fire_superiority_riflemen_us",
+    stateTreePath: ["ability_bag", "entity_tree"],
+    stateTree: "veterancy_1a_fire_superiority_riflemen_us",
+    weaponIds: [
+      "garand_rifleman_fire_superiority_us",
+      "thompson_riflemen_leader_fire_superiority_us",
+      "bar_riflemen_fire_superiority_us",
+    ],
+  },
+  {
     abilityId: "canister_shot_greyhound_us",
     stateTreePath: ["ability_bag", "entity_tree"],
     stateTree: "canister_shot_greyhound_us\\canister_timed\\swap_to_canister",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Weapon cards now display contextual timing labels based on available mechanics.

* **Bug Fixes**
  * Corrected DPS calculations to properly exclude inactive weapon members.
  * Time costs in unit upgrades now correctly recognized and calculated.

* **Localization**
  * Added weapon timing terminology translations (Pre-Fire Time, Wind Up).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->