### PR TITLE
Final stand

### DIFF
--- a/__tests__/src/unitStats/finalStand.test.ts
+++ b/__tests__/src/unitStats/finalStand.test.ts
@@ -1,0 +1,56 @@
+import {
+  filterFinalStandUnits,
+  isFinalStandFaction,
+  isFinalStandUnit,
+  isFinalStandUnitId,
+} from "../../../src/unitStats/finalStand";
+
+describe("isFinalStandUnitId", () => {
+  it("detects the hoff_ prefix used by all Final Stand units", () => {
+    expect(isFinalStandUnitId("hoff_enemy_fallschirmjagers_ger")).toBe(true);
+    expect(isFinalStandUnitId("hoff_player_riflemen_us")).toBe(true);
+  });
+
+  it("returns false for regular units and missing ids", () => {
+    expect(isFinalStandUnitId("panzergrenadier_ak")).toBe(false);
+    expect(isFinalStandUnitId("riflemen_us")).toBe(false);
+    expect(isFinalStandUnitId("")).toBe(false);
+    expect(isFinalStandUnitId(undefined)).toBe(false);
+    expect(isFinalStandUnitId(null)).toBe(false);
+  });
+});
+
+describe("isFinalStandUnit", () => {
+  it("uses the data file path when available", () => {
+    expect(isFinalStandUnit({ id: "hoff_enemy_sniper_us", path: "hoff/american/infantry" })).toBe(
+      true,
+    );
+    expect(isFinalStandUnit({ id: "riflemen_us", path: "races/american/infantry" })).toBe(false);
+  });
+
+  it("falls back to the id when there is no path", () => {
+    expect(isFinalStandUnit({ id: "hoff_enemy_sniper_us" })).toBe(true);
+    expect(isFinalStandUnit({ id: "riflemen_us" })).toBe(false);
+    expect(isFinalStandUnit(undefined)).toBe(false);
+  });
+});
+
+describe("isFinalStandFaction", () => {
+  it("only matches the hoff folder weapons / upgrades are mapped to", () => {
+    expect(isFinalStandFaction("hoff")).toBe(true);
+    expect(isFinalStandFaction("american")).toBe(false);
+    expect(isFinalStandFaction(undefined)).toBe(false);
+  });
+});
+
+describe("filterFinalStandUnits", () => {
+  const units = [{ id: "riflemen_us" }, { id: "hoff_enemy_riflemen_us" }];
+
+  it("removes Final Stand units by default", () => {
+    expect(filterFinalStandUnits(units, false)).toEqual([{ id: "riflemen_us" }]);
+  });
+
+  it("keeps them when they are asked for", () => {
+    expect(filterFinalStandUnits(units, true)).toEqual(units);
+  });
+});

--- a/components/final-stand-badge.tsx
+++ b/components/final-stand-badge.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Badge, MantineSize, Tooltip } from "@mantine/core";
+import { useTranslation } from "next-i18next/pages";
+
+interface FinalStandBadgeProps {
+  size?: MantineSize;
+  /** Weapons get a slightly different explanation than units. */
+  type?: "unit" | "weapon";
+  /** Set to false when the badge sits inside an element which already has a tooltip. */
+  withTooltip?: boolean;
+}
+
+/**
+ * Marks units / weapons which come from the Final Stand DLC (`hoff` in the game files). Those are
+ * not available in the standard skirmish / multiplayer game, see `src/unitStats/finalStand.ts`.
+ */
+export const FinalStandBadge = ({
+  size = "sm",
+  type = "unit",
+  withTooltip = true,
+}: FinalStandBadgeProps) => {
+  const { t } = useTranslation("common");
+
+  const badge = (
+    <Badge
+      variant="light"
+      color="teal"
+      size={size}
+      style={{ flexShrink: 0 }}
+      data-testid="final-stand-badge"
+    >
+      {t("finalStand.badge")}
+    </Badge>
+  );
+
+  if (!withTooltip) return badge;
+
+  return (
+    <Tooltip
+      label={t(type === "weapon" ? "finalStand.weaponTooltip" : "finalStand.unitTooltip")}
+      multiline
+      w={280}
+      withArrow
+    >
+      {badge}
+    </Tooltip>
+  );
+};
+
+export default FinalStandBadge;

--- a/components/unit-cards/unit-description-card.tsx
+++ b/components/unit-cards/unit-description-card.tsx
@@ -4,6 +4,7 @@ import ImageWithFallback from "../placeholders";
 import { raceType } from "../../src/coh3/coh3-types";
 import { getIconsPathOnCDN } from "../../src/utils";
 import { BattlegroupBackgrounds } from "../../src/unitStats";
+import { FinalStandBadge } from "../final-stand-badge";
 
 /**
  * These fields can be found at `sbps` inside each unit object.
@@ -33,10 +34,13 @@ export const UnitDescriptionCard = ({
   desc,
   faction,
   placement,
+  isFinalStand,
 }: {
   desc: UnitDescription;
   faction: raceType;
   placement?: "list" | "singleUnit" | "building";
+  /** Shows the Final Stand DLC badge next to the name. */
+  isFinalStand?: boolean;
 }) => {
   const factionBackgroundSrc = BattlegroupBackgrounds[faction];
 
@@ -95,6 +99,7 @@ export const UnitDescriptionCard = ({
             >
               {desc.screen_name}
             </Title>
+            {isFinalStand && <FinalStandBadge size={placement === "singleUnit" ? "md" : "sm"} />}
           </Flex>
 
           {/* Symbol horizontal aligned with brief text. */}

--- a/components/unitStats/dps/components/CompareSettingsPanel.tsx
+++ b/components/unitStats/dps/components/CompareSettingsPanel.tsx
@@ -17,13 +17,17 @@ import { getFactionIcon } from "../../../../src/unitStats";
 
 interface CompareSettingsPanelProps {
   allowAllWeapons: boolean;
+  showFinalStand: boolean;
   onAllowAllWeaponsChange: (checked: boolean) => void;
+  onShowFinalStandChange: (checked: boolean) => void;
   onResetUnits: () => void;
 }
 
 export const CompareSettingsPanel: React.FC<CompareSettingsPanelProps> = ({
   allowAllWeapons,
+  showFinalStand,
   onAllowAllWeaponsChange,
+  onShowFinalStandChange,
   onResetUnits,
 }) => {
   const handleAllowAllWeaponsChange = (checked: boolean) => {
@@ -54,6 +58,19 @@ export const CompareSettingsPanel: React.FC<CompareSettingsPanelProps> = ({
             }
             checked={allowAllWeapons}
             onChange={(event) => handleAllowAllWeaponsChange(event.currentTarget.checked)}
+          />
+          <Switch
+            label={
+              <Stack gap="0">
+                <>Final Stand Units</>
+                <Text size="xs" c="dimmed">
+                  Units from the Final Stand DLC (co-op vs AI). Deselects current units
+                </Text>
+              </Stack>
+            }
+            checked={showFinalStand}
+            onChange={(event) => onShowFinalStandChange(event.currentTarget.checked)}
+            data-testid="final-stand-toggle"
           />
           <Space />
           <Button variant="light" size="xs" onClick={onResetUnits}>

--- a/components/unitStats/dps/components/SettingsPanel.tsx
+++ b/components/unitStats/dps/components/SettingsPanel.tsx
@@ -5,16 +5,20 @@ import { IconAdjustments } from "@tabler/icons-react";
 interface SettingsPanelProps {
   showDpsHealth: boolean;
   allowAllWeapons: boolean;
+  showFinalStand: boolean;
   onShowDpsHealthChange: (checked: boolean) => void;
   onAllowAllWeaponsChange: (checked: boolean) => void;
+  onShowFinalStandChange: (checked: boolean) => void;
   onResetUnits: () => void;
 }
 
 export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   showDpsHealth,
   allowAllWeapons,
+  showFinalStand,
   onShowDpsHealthChange,
   onAllowAllWeaponsChange,
+  onShowFinalStandChange,
   onResetUnits,
 }) => {
   const handleAllowAllWeaponsChange = (checked: boolean) => {
@@ -53,6 +57,20 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
               }
               checked={allowAllWeapons}
               onChange={(event) => handleAllowAllWeaponsChange(event.currentTarget.checked)}
+            />
+            <Space />
+            <Switch
+              label={
+                <Stack gap="0">
+                  <>Final Stand Units</>
+                  <Text size="xs" c="dimmed">
+                    Units from the Final Stand DLC (co-op vs AI). Deselects current units
+                  </Text>
+                </Stack>
+              }
+              checked={showFinalStand}
+              onChange={(event) => onShowFinalStandChange(event.currentTarget.checked)}
+              data-testid="final-stand-toggle"
             />
           </Stack>
         </HoverCard.Dropdown>

--- a/components/unitStats/dps/dpsComparePageComponent.tsx
+++ b/components/unitStats/dps/dpsComparePageComponent.tsx
@@ -34,6 +34,7 @@ import { IconPlus } from "@tabler/icons-react";
 import { EbpsType, getEbpsStats } from "../../../src/unitStats/mappingEbps";
 import { getWeaponStats, WeaponType } from "../../../src/unitStats/mappingWeapon";
 import { getSbpsStats, SbpsType } from "../../../src/unitStats/mappingSbps";
+import { isFinalStandUnit } from "../../../src/unitStats/finalStand";
 import { UpgradesType } from "../../../src/unitStats/mappingUpgrades";
 import { AbilitiesType, getAbilitiesStats } from "../../../src/unitStats/mappingAbilities";
 import {
@@ -57,6 +58,7 @@ import {
 import { UnitCustomizationPanel } from "./components/UnitCustomizationPanel";
 import { ChartPanel } from "./components/ChartPanel";
 import { UnitSearch } from "./unitSearch";
+import { FinalStandBadge } from "../../final-stand-badge";
 import { mapChartData, options } from "./dpsPageComponent";
 import { DpsUnitCustomizing } from "./dpsUnitCustomizing";
 
@@ -110,12 +112,15 @@ const mapUnitSelection = (
   sbps: SbpsType[],
   units: CustomizableUnit[],
   unitFilter: string[] = [],
+  showFinalStand = false,
 ) => {
   const selectionFields: CustomizableUnit[] = [];
   for (const squad of sbps) {
     if (
       squad.ui.symbolIconName !== "" &&
       squad.faction !== "british" &&
+      // Final Stand (DLC / co-op vs AI) units are opt-in.
+      (showFinalStand || !isFinalStandUnit(squad)) &&
       (unitFilter.length === 0 || unitFilter.includes(squad.faction))
     ) {
       const custUnit = units.find((u) => u.id === squad.id);
@@ -154,6 +159,8 @@ export const DpsComparePageComponent: React.FC<IDPSCompareProps> = (props) => {
   const [patchVersion, setPatchVersion] = useState(config.latestPatch);
   const [factionFilter, setFactionFilter] = useState<string[]>([]);
   const [allowAllWeapons, setAllowAllWeapons] = useState(false);
+  // Final Stand (DLC / co-op vs AI) units are opt-in.
+  const [showFinalStand, setShowFinalStand] = useState(false);
   const [rerender, setRerender] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -172,13 +179,17 @@ export const DpsComparePageComponent: React.FC<IDPSCompareProps> = (props) => {
   // Initialize data
   useEffect(() => {
     initCompareData(props);
-    setUnitSelectionList(mapUnitSelection(cachedSbps, cachedUnits, factionFilter));
+    setUnitSelectionList(
+      mapUnitSelection(cachedSbps, cachedUnits, factionFilter, showFinalStand),
+    );
   }, []);
 
-  // Update selection list when filter changes
+  // Update selection list when the filters change
   useEffect(() => {
-    setUnitSelectionList(mapUnitSelection(cachedSbps, cachedUnits, factionFilter));
-  }, [factionFilter]);
+    setUnitSelectionList(
+      mapUnitSelection(cachedSbps, cachedUnits, factionFilter, showFinalStand),
+    );
+  }, [factionFilter, showFinalStand]);
 
   // Patch list
   const patchList = Object.keys(config.patches);
@@ -208,7 +219,9 @@ export const DpsComparePageComponent: React.FC<IDPSCompareProps> = (props) => {
           mapCustomizableUnit(sbps, newEbps, newWeapons, props.upgradesData, newAbilities),
         );
       }
-      setUnitSelectionList(mapUnitSelection(cachedSbps, cachedUnits, factionFilter));
+      setUnitSelectionList(
+        mapUnitSelection(cachedSbps, cachedUnits, factionFilter, showFinalStand),
+      );
 
       // Re-select units with new patch data
       if (targetUnit) {
@@ -289,6 +302,12 @@ export const DpsComparePageComponent: React.FC<IDPSCompareProps> = (props) => {
     setSelectedUnitToAdd(null);
   };
 
+  // Hiding Final Stand units again would leave already selected ones on the chart.
+  const handleShowFinalStandChange = (checked: boolean) => {
+    handleResetUnits();
+    setShowFinalStand(checked);
+  };
+
   // Update health for all units
   if (targetUnit) updateHealth(targetUnit);
   attackingUnits.forEach((unit) => {
@@ -341,7 +360,9 @@ export const DpsComparePageComponent: React.FC<IDPSCompareProps> = (props) => {
           </Flex>
           <CompareSettingsPanel
             allowAllWeapons={allowAllWeapons}
+            showFinalStand={showFinalStand}
             onAllowAllWeaponsChange={setAllowAllWeapons}
+            onShowFinalStandChange={handleShowFinalStandChange}
             onResetUnits={handleResetUnits}
           />
         </Group>
@@ -397,9 +418,12 @@ export const DpsComparePageComponent: React.FC<IDPSCompareProps> = (props) => {
                 }}
               >
                 <Flex justify="space-between" align="center" mb="xs">
-                  <Text size="sm" fw={500} c={ATTACKER_COLORS[index]}>
-                    {attacker.screen_name || attacker.id}
-                  </Text>
+                  <Group gap="xs" wrap="nowrap">
+                    <Text size="sm" fw={500} c={ATTACKER_COLORS[index]}>
+                      {attacker.screen_name || attacker.id}
+                    </Text>
+                    {isFinalStandUnit({ id: attacker.id }) && <FinalStandBadge size="xs" />}
+                  </Group>
                   <CloseButton size="sm" onClick={() => handleRemoveAttacker(index)} />
                 </Flex>
                 <DpsUnitCustomizing

--- a/components/unitStats/dps/dpsPageComponent.tsx
+++ b/components/unitStats/dps/dpsPageComponent.tsx
@@ -27,6 +27,7 @@ import { getDPSCompareRoute } from "../../../src/routes";
 import { EbpsType, getEbpsStats } from "../../../src/unitStats/mappingEbps";
 import { getWeaponStats, WeaponType } from "../../../src/unitStats/mappingWeapon";
 import { getSbpsStats, SbpsType } from "../../../src/unitStats/mappingSbps";
+import { isFinalStandUnit } from "../../../src/unitStats/finalStand";
 import { UpgradesType } from "../../../src/unitStats/mappingUpgrades";
 import { AbilitiesType, getAbilitiesStats } from "../../../src/unitStats/mappingAbilities";
 import {
@@ -150,6 +151,7 @@ const mapUnitSelection = (
   sbps: SbpsType[],
   units: CustomizableUnit[],
   unitFilter: string[] = [],
+  showFinalStand = false,
 ) => {
   const selectionFields = [];
 
@@ -157,6 +159,8 @@ const mapUnitSelection = (
     if (
       squad.ui.symbolIconName != "" &&
       squad.faction != "british" &&
+      // Final Stand (DLC / co-op vs AI) units are opt-in.
+      (showFinalStand || !isFinalStandUnit(squad)) &&
       (unitFilter.length == 0 || unitFilter.includes(squad.faction))
     ) {
       const custUnit = units.find((custUnit) => custUnit.id == squad.id);
@@ -233,6 +237,8 @@ export const DpsPageComponent = (props: IDPSProps) => {
   const [isStaircase] = useState(false);
   const [showDpsHealth, setShowDpsHealth] = useState(false);
   const [allowAllWeapons, setAllowAllWeapons] = useState(false);
+  // Final Stand (DLC / co-op vs AI) units are opt-in.
+  const [showFinalStand, setShowFinalStand] = useState(false);
 
   // const { classes } = useStyles();
   const theme = useMantineTheme();
@@ -260,9 +266,9 @@ export const DpsPageComponent = (props: IDPSProps) => {
 
   // create selection List
   if (unitSelectionList1.length == 0 && props.sbpsData.length > 0)
-    unitSelectionList1 = mapUnitSelection(props.sbpsData, units1, unitFilter1);
+    unitSelectionList1 = mapUnitSelection(props.sbpsData, units1, unitFilter1, showFinalStand);
   if (unitSelectionList2.length == 0 && props.sbpsData.length > 0)
-    unitSelectionList2 = mapUnitSelection(props.sbpsData, units2, unitFilter2);
+    unitSelectionList2 = mapUnitSelection(props.sbpsData, units2, unitFilter2, showFinalStand);
 
   const chartData = { datasets: [mapChartData([])] };
 
@@ -329,6 +335,16 @@ export const DpsPageComponent = (props: IDPSProps) => {
     else setFilter2([...unitFilter]);
   };
 
+  // Toggling Final Stand units changes the selection lists, so they get rebuilt (they are rebuilt
+  // when empty) and the currently selected units are cleared.
+  const onShowFinalStandChange = (checked: boolean) => {
+    unitSelectionList1.splice(0, unitSelectionList1.length);
+    unitSelectionList2.splice(0, unitSelectionList2.length);
+    onSelectionChange(null, 0);
+    onSelectionChange(null, 1);
+    setShowFinalStand(checked);
+  };
+
   useEffect(() => {
     const getPatchStats = async () => {
       // Get Patch data from cache or fetch
@@ -348,7 +364,7 @@ export const DpsPageComponent = (props: IDPSProps) => {
               abilityData1,
             ),
           );
-        unitSelectionList1 = mapUnitSelection(sbpsData1, units1, unitFilter1);
+        unitSelectionList1 = mapUnitSelection(sbpsData1, units1, unitFilter1, showFinalStand);
         if (activeData[0]) {
           const id = activeData[0].id;
           activeData[0] = {} as CustomizableUnit;
@@ -370,7 +386,7 @@ export const DpsPageComponent = (props: IDPSProps) => {
               abilityData2,
             ),
           );
-        unitSelectionList2 = mapUnitSelection(sbpsData2, units2, unitFilter2);
+        unitSelectionList2 = mapUnitSelection(sbpsData2, units2, unitFilter2, showFinalStand);
         if (activeData[1]) {
           const id = activeData[1].id;
           activeData[1] = {} as CustomizableUnit;
@@ -462,8 +478,10 @@ export const DpsPageComponent = (props: IDPSProps) => {
               <SettingsPanel
                 showDpsHealth={showDpsHealth}
                 allowAllWeapons={allowAllWeapons}
+                showFinalStand={showFinalStand}
                 onShowDpsHealthChange={setShowDpsHealth}
                 onAllowAllWeaponsChange={setAllowAllWeapons}
+                onShowFinalStandChange={onShowFinalStandChange}
                 onResetUnits={() => {
                   onSelectionChange(null, 0);
                   onSelectionChange(null, 1);

--- a/components/unitStats/dps/unitSearch.tsx
+++ b/components/unitStats/dps/unitSearch.tsx
@@ -1,8 +1,9 @@
 import { Group, Text, Image, Select, HoverCard, Stack, SelectProps } from "@mantine/core";
 import { UnitCostCard } from "../../unit-cards/unit-cost-card";
 import { CustomizableUnit } from "../../../src/unitStats/dpsCommon";
-import { ebpsStats, getSquadTotalCost } from "../../../src/unitStats";
+import { ebpsStats, getSquadTotalCost, isFinalStandUnitId } from "../../../src/unitStats";
 import { Line } from "react-chartjs-2";
+import { FinalStandBadge } from "../../final-stand-badge";
 
 // interface ItemProps extends React.ComponentPropsWithoutRef<"div"> {
 //   image: string;
@@ -104,7 +105,12 @@ const renderSelectOption: SelectProps["renderOption"] = ({ option }) => {
         </HoverCard>
 
         <div>
-          <Text size="sm">{label}</Text>
+          <Group gap="xs" wrap="nowrap">
+            <Text size="sm">{label}</Text>
+            {isFinalStandUnitId((option as CustomizableUnit).id) && (
+              <FinalStandBadge size="xs" withTooltip={false} />
+            )}
+          </Group>
           <Text size="xs" opacity={0.65}>
             {description}
           </Text>

--- a/components/unitStats/dps/weaponSearch.tsx
+++ b/components/unitStats/dps/weaponSearch.tsx
@@ -1,5 +1,7 @@
 import { Group, Text, Image, Select, SelectProps } from "@mantine/core";
 import { WeaponMember } from "../../../src/unitStats/dpsCommon";
+import { isFinalStandFaction } from "../../../src/unitStats/finalStand";
+import { FinalStandBadge } from "../../final-stand-badge";
 
 interface ItemProps extends React.ComponentPropsWithoutRef<"div"> {
   image: string;
@@ -9,6 +11,7 @@ interface ItemProps extends React.ComponentPropsWithoutRef<"div"> {
 
 const renderSelectOption: SelectProps["renderOption"] = ({ option }) => {
   const { image, label, description } = option as unknown as ItemProps;
+  const isFinalStand = isFinalStandFaction((option as unknown as WeaponMember).weapon?.faction);
 
   return (
     <div>
@@ -23,7 +26,10 @@ const renderSelectOption: SelectProps["renderOption"] = ({ option }) => {
           alt="Weapon Class"
         />
         <div>
-          <Text size="sm">{label}</Text>
+          <Group gap="xs" wrap="nowrap">
+            <Text size="sm">{label}</Text>
+            {isFinalStand && <FinalStandBadge size="xs" type="weapon" withTooltip={false} />}
+          </Group>
           <Text size="xs" opacity={0.65}>
             {description}
           </Text>

--- a/components/unitStats/unitTable.tsx
+++ b/components/unitStats/unitTable.tsx
@@ -15,6 +15,7 @@ import {
   HoverCard,
   Stack,
   Checkbox,
+  Switch,
   Tooltip,
   ActionIcon,
   Anchor,
@@ -28,8 +29,9 @@ import {
   IconSearch,
   IconSelector,
 } from "@tabler/icons-react";
-import { getFactionIcon } from "../../src/unitStats";
+import { getFactionIcon, isFinalStandUnitId } from "../../src/unitStats";
 import { CustomizableUnit } from "../../src/unitStats/dpsCommon";
+import { FinalStandBadge } from "../final-stand-badge";
 import { internalSlash } from "../../src/utils";
 import { getExplorerUnitRoute } from "../../src/routes";
 import { raceType } from "../../src/coh3/coh3-types";
@@ -255,17 +257,20 @@ const getCellVisual = (colSetup: tableColSetup, unit: CustomizableUnit) => {
   if (!colSetup.customVisual) {
     if (colSetup.key === "screen_name") {
       return (
-        <Tooltip label={(unit as any)[colSetup.key]}>
-          <Anchor
-            c="orange"
-            component={LinkWithOutPrefetch}
-            href={getExplorerUnitRoute(unit.faction as raceType, unit.id)}
-          >
-            <Text style={{ textOverflow: "ellipsis", overflow: "hidden" }}>
-              {(unit as any)[colSetup.key]}
-            </Text>
-          </Anchor>
-        </Tooltip>
+        <Group gap="xs" wrap="nowrap">
+          <Tooltip label={(unit as any)[colSetup.key]}>
+            <Anchor
+              c="orange"
+              component={LinkWithOutPrefetch}
+              href={getExplorerUnitRoute(unit.faction as raceType, unit.id)}
+            >
+              <Text style={{ textOverflow: "ellipsis", overflow: "hidden" }}>
+                {(unit as any)[colSetup.key]}
+              </Text>
+            </Anchor>
+          </Tooltip>
+          {isFinalStandUnitId(unit.id) && <FinalStandBadge size="xs" />}
+        </Group>
       );
     }
 
@@ -320,6 +325,7 @@ const filterData = (
   search: string,
   factionFilter: string[],
   typeFilter: string[],
+  showFinalStand: boolean,
 ) => {
   const query = search.toLowerCase().trim();
   let result = data.filter((item) =>
@@ -329,6 +335,8 @@ const filterData = (
         typeof item[key] == "string" && (item[key] as string).toLowerCase().includes(query),
     ),
   );
+  // Final Stand (DLC / co-op vs AI) units are opt-in.
+  if (!showFinalStand) result = result.filter((item) => !isFinalStandUnitId(item.id));
   result = applyFilter(result, factionFilter, "faction");
   result = applyFilter(result, typeFilter, "unit_type");
   return result;
@@ -342,12 +350,19 @@ const sortData = (
     search: string;
     factionFilter: string[];
     typeFilter: string[];
+    showFinalStand: boolean;
   },
 ) => {
   const { sortBy } = payload;
 
   if (!sortBy) {
-    return filterData(data, payload.search, payload.factionFilter, payload.typeFilter);
+    return filterData(
+      data,
+      payload.search,
+      payload.factionFilter,
+      payload.typeFilter,
+      payload.showFinalStand,
+    );
   }
 
   return filterData(
@@ -371,6 +386,7 @@ const sortData = (
     payload.search,
     payload.factionFilter,
     payload.typeFilter,
+    payload.showFinalStand,
   );
 };
 
@@ -509,9 +525,11 @@ export const UnitTable = ({ inputData }: inputProps) => {
   const [search, setSearch] = useState("");
   const [factionFilter, setFactionFilter] = useState([] as string[]);
   const [typeFilter, setTypeFilter] = useState([] as string[]);
+  // Final Stand (DLC / co-op vs AI) units are opt-in.
+  const [showFinalStand, setShowFinalStand] = useState(false);
 
   const [updateFlag, updateTable] = useState(true);
-  const [sortedData, setSortedData] = useState(tableData);
+  const [sortedData, setSortedData] = useState(() => filterData(tableData, "", [], [], false));
   const [sortBy, setSortBy] = useState<keyof CustomizableUnit | null>(null);
   const [reverseSortDirection, setReverseSortDirection] = useState(false);
 
@@ -525,9 +543,10 @@ export const UnitTable = ({ inputData }: inputProps) => {
         search: debouncedSearch,
         factionFilter,
         typeFilter,
+        showFinalStand,
       }),
     );
-  }, [debouncedSearch]);
+  }, [debouncedSearch, showFinalStand]);
 
   function toggleFilter(filterValue: string, filterList: string[]) {
     const filterValueIndex = filterList.indexOf(filterValue);
@@ -543,6 +562,7 @@ export const UnitTable = ({ inputData }: inputProps) => {
         search: search,
         factionFilter,
         typeFilter,
+        showFinalStand,
       }),
     );
   }
@@ -552,7 +572,14 @@ export const UnitTable = ({ inputData }: inputProps) => {
     setReverseSortDirection(reversed);
     setSortBy(field);
     setSortedData(
-      sortData(tableData, { sortBy: field, reversed, search, factionFilter, typeFilter }),
+      sortData(tableData, {
+        sortBy: field,
+        reversed,
+        search,
+        factionFilter,
+        typeFilter,
+        showFinalStand,
+      }),
     );
   };
 
@@ -622,6 +649,14 @@ export const UnitTable = ({ inputData }: inputProps) => {
             </Group>
             <Space w={"md"} />
             <Group wrap="nowrap">{generateTypeFilterButtons(toggleFilter, typeFilter)}</Group>
+            <Space w={"md"} />
+            <Switch
+              checked={showFinalStand}
+              onChange={(event) => setShowFinalStand(event.currentTarget.checked)}
+              label={"Final Stand units"}
+              data-testid="final-stand-toggle"
+              size="sm"
+            />
           </Group>
           <TextInput
             placeholder="Search Unit"

--- a/components/unitStats/weaponTable.tsx
+++ b/components/unitStats/weaponTable.tsx
@@ -1,10 +1,20 @@
 import { useEffect, useState } from "react";
-import { Group, TextInput, Image, Title, Space, Tooltip, ActionIcon } from "@mantine/core";
+import {
+  Group,
+  TextInput,
+  Image,
+  Title,
+  Space,
+  Switch,
+  Tooltip,
+  ActionIcon,
+} from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
 import { IconSearch } from "@tabler/icons-react";
 
-import { getFactionIcon, WeaponClass } from "../../src/unitStats";
+import { getFactionIcon, isFinalStandFaction, WeaponClass } from "../../src/unitStats";
 import { getIconsPathOnCDN, internalSlash } from "../../src/utils";
+import { FinalStandBadge } from "../final-stand-badge";
 
 import { DataTable, DataTableColumnGroup } from "mantine-datatable";
 
@@ -141,6 +151,12 @@ const TableGroups: DataTableColumnGroup<WeaponTableRow>[] = [
         accessor: "screen_name",
         title: "Name",
         // toggleable: true,
+        render: (record) => (
+          <Group gap="xs" wrap="nowrap">
+            <span>{record.screen_name}</span>
+            {isFinalStandFaction(record.faction) && <FinalStandBadge size="xs" type="weapon" />}
+          </Group>
+        ),
       },
     ],
   },
@@ -315,6 +331,7 @@ const filterData = (
   search: string,
   factionFilter: string[],
   typeFilter: string[],
+  showFinalStand: boolean,
 ) => {
   const query = search.toLowerCase().trim();
   let result = data.filter((item) =>
@@ -323,6 +340,8 @@ const filterData = (
         typeof item[key] == "string" && (item[key] as string).toLowerCase().includes(query),
     ),
   );
+  // Final Stand (DLC / co-op vs AI) weapons are opt-in.
+  if (!showFinalStand) result = result.filter((item) => !isFinalStandFaction(item.faction));
   result = applyFilter(result, factionFilter, "faction");
   result = applyFilter(result, typeFilter, "type");
   return result;
@@ -336,12 +355,19 @@ const sortData = (
     search: string;
     factionFilter: string[];
     typeFilter: string[];
+    showFinalStand: boolean;
   },
 ) => {
   const { sortBy } = payload;
 
   if (!sortBy) {
-    return filterData(data, payload.search, payload.factionFilter, payload.typeFilter);
+    return filterData(
+      data,
+      payload.search,
+      payload.factionFilter,
+      payload.typeFilter,
+      payload.showFinalStand,
+    );
   }
 
   return filterData(
@@ -365,6 +391,7 @@ const sortData = (
     payload.search,
     payload.factionFilter,
     payload.typeFilter,
+    payload.showFinalStand,
   );
 };
 
@@ -511,8 +538,10 @@ export const WeaponTable = ({ inputData }: inputProps) => {
   const [search, setSearch] = useState("");
   const [factionFilter, setFactionFilter] = useState([] as string[]);
   const [typeFilter, setTypeFilter] = useState([] as string[]);
+  // Final Stand (DLC / co-op vs AI) weapons are opt-in.
+  const [showFinalStand, setShowFinalStand] = useState(false);
 
-  const [sortedData, setSortedData] = useState(tableData);
+  const [sortedData, setSortedData] = useState(() => filterData(tableData, "", [], [], false));
   const [pagedData, setPagedData] = useState(sortedData.slice(0, PAGE_SIZE));
 
   const [sortBy] = useState<keyof WeaponTableRow | null>(null);
@@ -536,9 +565,10 @@ export const WeaponTable = ({ inputData }: inputProps) => {
         search: debouncedSearch,
         factionFilter,
         typeFilter,
+        showFinalStand,
       }),
     );
-  }, [debouncedSearch]);
+  }, [debouncedSearch, showFinalStand]);
 
   function toggleFilter(filterValue: string, filterList: string[]) {
     const filterValueIndex = filterList.indexOf(filterValue);
@@ -554,6 +584,7 @@ export const WeaponTable = ({ inputData }: inputProps) => {
         search: search,
         factionFilter,
         typeFilter,
+        showFinalStand,
       }),
     );
   }
@@ -574,6 +605,14 @@ export const WeaponTable = ({ inputData }: inputProps) => {
             <Group wrap="wrap">
               {generateWeaponClassFilterButtons(toggleFilter, typeFilter)}
             </Group>
+            <Space w={"md"} />
+            <Switch
+              checked={showFinalStand}
+              onChange={(event) => setShowFinalStand(event.currentTarget.checked)}
+              label={"Final Stand weapons"}
+              data-testid="final-stand-toggle"
+              size="sm"
+            />
           </Group>
           <TextInput
             placeholder="Search Weapon"

--- a/e2e/regression/final-stand.spec.ts
+++ b/e2e/regression/final-stand.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+import { navigateAndWait } from "../helpers/test-utils";
+
+/**
+ * Final Stand (DLC / co-op vs AI, `hoff` in the game files) units are hidden by default everywhere
+ * we list units, and marked with a badge when they are shown.
+ */
+test.describe("Final Stand units", () => {
+  test("faction unit list hides them until the toggle is switched on", async ({ page }) => {
+    await navigateAndWait(page, "/explorer/races/american/units");
+
+    const unitTitles = page.getByTestId("unit-title");
+    const regularUnits = await unitTitles.count();
+    expect(regularUnits).toBeGreaterThan(0);
+    await expect(page.getByTestId("final-stand-badge")).toHaveCount(0);
+
+    await page.getByTestId("final-stand-toggle").check();
+
+    expect(await unitTitles.count()).toBeGreaterThan(regularUnits);
+    expect(await page.getByTestId("final-stand-badge").count()).toBeGreaterThan(0);
+  });
+
+  test("unit browser hides them until the toggle is switched on", async ({ page }) => {
+    await navigateAndWait(page, "/explorer/unit-browser");
+
+    await expect(page.getByTestId("final-stand-badge")).toHaveCount(0);
+
+    await page.getByTestId("final-stand-toggle").check();
+
+    await expect(page.getByTestId("final-stand-badge").first()).toBeVisible();
+  });
+
+  test("DPS calculator offers them only when enabled in the settings", async ({ page }) => {
+    await navigateAndWait(page, "/explorer/dps");
+
+    const unitSearch = page.getByPlaceholder("Choose unit").first();
+    await unitSearch.click();
+    await unitSearch.fill("hoff_");
+    await expect(page.getByTestId("final-stand-badge")).toHaveCount(0);
+    await page.keyboard.press("Escape");
+
+    await page.getByRole("button", { name: "Settings" }).first().hover();
+    await page.getByTestId("final-stand-toggle").first().check();
+
+    await unitSearch.click();
+    await unitSearch.fill("hoff_");
+    await expect(page.getByTestId("final-stand-badge").first()).toBeVisible();
+  });
+
+  test("unit detail page marks a Final Stand unit", async ({ page }) => {
+    await navigateAndWait(page, "/explorer/races/german/units/hoff_enemy_fallschirmjagers_ger");
+
+    await expect(page.getByTestId("final-stand-badge")).toBeVisible();
+  });
+
+  test("unit detail page does not mark a regular unit", async ({ page }) => {
+    await navigateAndWait(page, "/explorer/races/german/units/grenadier_ger");
+
+    await expect(page.getByTestId("final-stand-badge")).toHaveCount(0);
+  });
+});

--- a/pages/explorer/races/[raceId]/units/[unitId].tsx
+++ b/pages/explorer/races/[raceId]/units/[unitId].tsx
@@ -21,6 +21,7 @@ import {
   getResolvedAbilities,
   getResolvedConstruction,
   getResolvedUpgrades,
+  isFinalStandUnit,
   getSquadTotalCost,
   getSquadTotalUpkeepCost,
   ResourceValues,
@@ -408,6 +409,7 @@ const UnitDetail: NextPage<UnitDetailProps> = ({ calculatedData, descriptions, l
                     icon_name: resolvedSquad.ui.iconName,
                   }}
                   placement="singleUnit"
+                  isFinalStand={isFinalStandUnit(resolvedSquad)}
                 />
               </Card>
               <Box style={{ display: "flex", alignItems: "stretch" }} visibleFrom="sm">

--- a/pages/explorer/races/[raceId]/units/index.tsx
+++ b/pages/explorer/races/[raceId]/units/index.tsx
@@ -6,7 +6,9 @@ import {
   Card,
   Flex,
   Grid,
+  Group,
   Stack,
+  Switch,
   Text,
   Title,
   Container,
@@ -20,7 +22,7 @@ import {
 } from "../../../../../src/seo-utils";
 import { localizedNames } from "../../../../../src/coh3/coh3-data";
 import { getMappings } from "../../../../../src/unitStats/mappings";
-import { SbpsType } from "../../../../../src/unitStats";
+import { isFinalStandUnit, SbpsType } from "../../../../../src/unitStats";
 import FactionIcon from "../../../../../components/faction-icon";
 import { UnitDescriptionCard } from "../../../../../components/unit-cards/unit-description-card";
 import LinkWithOutPrefetch from "../../../../../components/LinkWithOutPrefetch";
@@ -43,8 +45,11 @@ interface UnitDetailProps {
 const ExplorerUnits: NextPage<UnitDetailProps> = ({ units, raceToFetch, descriptions }) => {
   const { asPath } = useRouter();
   const { t } = useTranslation("explorer");
+  const { t: tCommon } = useTranslation("common");
   const localizedRace = localizedNames[raceToFetch];
   const [searchValue, setSearchValue] = useState("");
+  // Final Stand (DLC / co-op vs AI) units roughly double the roster, they are opt-in.
+  const [showFinalStand, setShowFinalStand] = useState(false);
 
   useEffect(() => {
     AnalyticsExplorerFactionUnitsView(raceToFetch);
@@ -55,8 +60,9 @@ const ExplorerUnits: NextPage<UnitDetailProps> = ({ units, raceToFetch, descript
     `Unit List ${localizedRace}`,
   ]);
 
-  // Filter units based on search value
+  // Filter units based on the Final Stand toggle and the search value
   const filteredUnits = units.filter((unit) => {
+    if (!showFinalStand && isFinalStandUnit(unit)) return false;
     if (!searchValue) return true;
     const searchLower = searchValue.toLowerCase();
     return (
@@ -106,6 +112,7 @@ const ExplorerUnits: NextPage<UnitDetailProps> = ({ units, raceToFetch, descript
                           icon_name: ui.iconName,
                         }}
                         placement="list"
+                        isFinalStand={isFinalStandUnit({ id })}
                       />
                     </Card>
                   </Anchor>
@@ -143,15 +150,37 @@ const ExplorerUnits: NextPage<UnitDetailProps> = ({ units, raceToFetch, descript
         </Flex>
 
         <Stack mt={32}>
-          <Flex direction="row" align="center" justify="space-between" gap="md">
+          <Flex
+            direction="row"
+            align="center"
+            justify="space-between"
+            gap="md"
+            wrap="wrap"
+            rowGap="sm"
+          >
             <Title order={2}>{descriptions.common?.units || "Units"}</Title>
-            <TextInput
-              placeholder="Search units"
-              leftSection={<IconSearch size="1rem" />}
-              value={searchValue}
-              onChange={(event) => setSearchValue(event.currentTarget.value)}
-              style={{ maxWidth: 300 }}
-            />
+            <Group gap="lg" wrap="wrap">
+              <Switch
+                checked={showFinalStand}
+                onChange={(event) => setShowFinalStand(event.currentTarget.checked)}
+                data-testid="final-stand-toggle"
+                label={
+                  <Stack gap={0}>
+                    <Text size="sm">{tCommon("finalStand.showUnits")}</Text>
+                    <Text size="xs" c="dimmed">
+                      {tCommon("finalStand.showUnitsDescription")}
+                    </Text>
+                  </Stack>
+                }
+              />
+              <TextInput
+                placeholder="Search units"
+                leftSection={<IconSearch size="1rem" />}
+                value={searchValue}
+                onChange={(event) => setSearchValue(event.currentTarget.value)}
+                style={{ maxWidth: 300 }}
+              />
+            </Group>
           </Flex>
 
           {renderUnitCategory("Infantry", infantryUnits)}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -71,6 +71,15 @@
   "search": {
     "playersAndUnits": "Players, Units and Maps"
   },
+  "finalStand": {
+    "badge": "Final Stand",
+    "unitTooltip": "This unit is from the Final Stand DLC (co-op vs AI). It's not available in the standard skirmish / multiplayer game.",
+    "weaponTooltip": "This weapon is from the Final Stand DLC (co-op vs AI). It's not available in the standard skirmish / multiplayer game.",
+    "showUnits": "Show Final Stand units",
+    "showUnitsDescription": "Units from the Final Stand DLC (co-op vs AI)",
+    "showWeapons": "Show Final Stand weapons",
+    "filterUnits": "Show / hide Final Stand units"
+  },
   "loading": "Loading...",
   "error": "Error",
   "notFound": "Not Found"

--- a/screens/search/index.tsx
+++ b/screens/search/index.tsx
@@ -24,6 +24,7 @@ import mapsData from "./maps-search-data.json";
 import { UnitCard, UnitData } from "./search-components/unit-card";
 import { MapCard, MapSearchData } from "./search-components/map-card";
 import { stripMpMapNamePrefix } from "../../src/explorer/mp-maps-helpers";
+import { isFinalStandUnitId } from "../../src/unitStats/finalStand";
 
 export const SearchScreen = () => {
   const [loading, setLoading] = React.useState(false);
@@ -48,6 +49,8 @@ export const SearchScreen = () => {
 
     const searchTermLower = searchTerm.toLowerCase();
     const results = unitsData.filter((unit) => unit.name.toLowerCase().includes(searchTermLower));
+    // Final Stand (DLC / co-op vs AI) units are marked as such and listed after the regular ones.
+    results.sort((a, b) => Number(isFinalStandUnitId(a.id)) - Number(isFinalStandUnitId(b.id)));
     setUnitResults(results);
   };
 

--- a/screens/search/search-components/unit-card.tsx
+++ b/screens/search/search-components/unit-card.tsx
@@ -9,6 +9,8 @@ import { raceType } from "../../../src/coh3/coh3-types";
 import { getExplorerUnitRoute } from "../../../src/routes";
 import Link from "next/link";
 import styles from "./unit-card.module.css";
+import { isFinalStandUnitId } from "../../../src/unitStats/finalStand";
+import { FinalStandBadge } from "../../../components/final-stand-badge";
 
 export interface UnitData {
   id: string;
@@ -59,6 +61,11 @@ export const UnitCard = ({ unit }: UnitCardProps) => (
           >
             {unit.name}
           </Text>
+          {isFinalStandUnitId(unit.id) && (
+            <Group gap="xs" mt={4}>
+              <FinalStandBadge size="xs" />
+            </Group>
+          )}
         </div>
       </Group>
     </Card>

--- a/src/unitStats/finalStand.ts
+++ b/src/unitStats/finalStand.ts
@@ -1,0 +1,64 @@
+/**
+ * Final Stand is the co-op vs AI DLC. It ships with its own set of units, weapons and upgrades which
+ * are not available in the standard skirmish / multiplayer game.
+ *
+ * The game files call Final Stand "hoff" (Hold Off) - all of its content lives in a top level `hoff`
+ * folder in the data files, and every unit file inside it is prefixed with `hoff_`
+ * (eg. `hoff_enemy_fallschirmjagers_ger`). Same as with the maps, we keep the raw data faithful to
+ * the game files and use the in-game name in the app level types / UI.
+ *
+ * Because the DLC content roughly doubles the amount of units per faction (and duplicates most of
+ * the multiplayer roster under `hoff_enemy_*` / `hoff_player_*` names), it's hidden by default
+ * everywhere we list units and has to be opted into.
+ */
+
+/** Prefix of every Final Stand unit / entity ID. */
+const FINAL_STAND_ID_PREFIX = "hoff_";
+
+/** Folder Final Stand content lives in, which is also the mapped `faction` of its weapons. */
+const FINAL_STAND_FOLDER = "hoff";
+
+/**
+ * Whether the given unit / entity ID belongs to the Final Stand DLC.
+ *
+ * Works for sbps (squads), ebps (entities) and any other ID which comes from the `hoff` folder.
+ */
+const isFinalStandUnitId = (id?: string | null): boolean =>
+  !!id && id.startsWith(FINAL_STAND_ID_PREFIX);
+
+/**
+ * Whether the given unit belongs to the Final Stand DLC. Prefers the mapped `path` (the folder
+ * structure of the data files) and falls back to the ID prefix.
+ */
+const isFinalStandUnit = (unit?: { id?: string; path?: string } | null): boolean => {
+  if (!unit) return false;
+  if (unit.path) return unit.path.split("/")[0] === FINAL_STAND_FOLDER;
+
+  return isFinalStandUnitId(unit.id);
+};
+
+/**
+ * Whether the given faction folder name is the Final Stand one. Weapons and upgrades are mapped with
+ * the top level folder as their faction, so Final Stand ones end up as `hoff`.
+ */
+const isFinalStandFaction = (faction?: string | null): boolean => faction === FINAL_STAND_FOLDER;
+
+/**
+ * Removes the Final Stand units from a list, unless they were asked for.
+ *
+ * @param units Units with an `id` (and optionally a `path`).
+ * @param includeFinalStand When true the list is returned as is.
+ */
+const filterFinalStandUnits = <T extends { id?: string; path?: string }>(
+  units: T[],
+  includeFinalStand: boolean,
+): T[] => (includeFinalStand ? units : units.filter((unit) => !isFinalStandUnit(unit)));
+
+export {
+  FINAL_STAND_ID_PREFIX,
+  FINAL_STAND_FOLDER,
+  isFinalStandUnitId,
+  isFinalStandUnit,
+  isFinalStandFaction,
+  filterFinalStandUnits,
+};

--- a/src/unitStats/index.ts
+++ b/src/unitStats/index.ts
@@ -1,5 +1,6 @@
 export * from "./battlegroup";
 export * from "./faction";
+export * from "./finalStand";
 export * from "./squadTotalCost";
 export * from "./locstring";
 export * from "./mappingAbilities";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Final Stand DLC badges to unit and weapon listings, search results, comparison views, and detail pages.
  - Added optional Final Stand filters across the unit explorer, unit and weapon tables, and DPS tools.
  - Final Stand content is hidden by default and can be enabled through clear display toggles.
  - Final Stand units and weapons are identified with contextual tooltips.

- **Bug Fixes**
  - Improved search ordering so regular content appears before Final Stand content.

- **Tests**
  - Added unit and end-to-end coverage for detection, filtering, visibility toggles, and badge display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->