### PR TITLE
fixed the official discord link local-news.ts

### DIFF
--- a/src/news/data/local-news.ts
+++ b/src/news/data/local-news.ts
@@ -43,7 +43,7 @@ const localNews: LocalNewsItem[] = [
 
 [h2]For more information[/h2]
 
-[p]if you want to join us for the next season, visit our [url=https://discord.gg/HQxUnjcrNd]discord[/url]Official Discord[/p]
+[p]if you want to join us for the next season, visit our [url=https://discord.gg/HQxUnjcrNd]Official Discord[/url][/p]
 
 [p][url=https://laddertournament.com.br/]Visit the Official Website[/url][/p]
 


### PR DESCRIPTION
fixed the official discord link local-news.ts

ladder tournament

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Official Discord invitation link in the Ladder Tournament Season `#1` Grand Final announcement.
  * The link now displays and directs correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->