### PR TITLE
Fix failing search e2e tests pinned to a single profile id

### DIFF
--- a/e2e/page-objects/search-page.ts
+++ b/e2e/page-objects/search-page.ts
@@ -59,6 +59,20 @@ export class SearchPage extends BasePage {
     return this.getByTestId(`search-player-card-${profileId}`);
   }
 
+  /**
+   * Read the relic profile id back out of a player card's test id. The player search API returns
+   * a capped, activity-ordered list, so the tests pick a card out of the response instead of
+   * pinning a profile that can drop out of it.
+   */
+  async profileIdOfCard(card: Locator): Promise<string> {
+    const testId = await card.getAttribute("data-testid");
+    const profileId = testId?.replace("search-player-card-", "");
+
+    expect(profileId).toMatch(/^\d+$/);
+
+    return profileId as string;
+  }
+
   get unitCards(): Locator {
     return this.page.locator('[data-testid^="search-unit-card-"]');
   }

--- a/e2e/regression/search.spec.ts
+++ b/e2e/regression/search.spec.ts
@@ -105,7 +105,10 @@ test.describe("Search Page - player results", () => {
     const profileId = await searchPage.profileIdOfCard(card);
 
     await card.click();
-    await page.waitForURL(new RegExp(`/players/${profileId}`));
+    // The page rewrites the URL to `/players/<id>/<cleanAlias>` once it has the player data, so
+    // anchor the id to a `/`, a query string or the end - `/players/1610` must not match
+    // `/players/16100`.
+    await page.waitForURL(new RegExp(`/players/${profileId}([/?]|$)`));
     // The card truncates long aliases, so assert on the query the API matched rather than on the
     // exact text of the card.
     await expect(page.getByTestId("player-name")).toContainText(

--- a/e2e/regression/search.spec.ts
+++ b/e2e/regression/search.spec.ts
@@ -75,29 +75,42 @@ test.describe("Search Page - ?q= hydration", () => {
 });
 
 test.describe("Search Page - player results", () => {
-  test("should find the pinned player and link to their profile", async ({ page }) => {
+  // The API answers with a capped list of the *recently active* profiles matching the alias, so
+  // no single profile is guaranteed to be in it - a pinned id silently drops out of the response
+  // once the player stops playing. These tests therefore assert on the first returned card.
+  test("should find players matching the query and link to their profile", async ({ page }) => {
     const searchPage = new SearchPage(page);
     await searchPage.navigate(TEST_PLAYER.alias);
     await expect(searchPage.playersResults).toBeVisible({ timeout: 30000 });
 
-    const card = searchPage.playerCard(TEST_PLAYER.profileId);
+    const card = searchPage.playerCards.first();
     await expect(card).toBeVisible();
-    await expect(card).toContainText(TEST_PLAYER.alias);
+    // Every returned alias contains the query (the API matches on a substring of the alias).
+    await expect(card).toContainText(new RegExp(TEST_PLAYER.alias, "i"));
     // Last-active line.
     await expect(card).toContainText(/Last active/i);
 
-    const link = page.locator(`a[href="/players/${TEST_PLAYER.profileId}"]`).first();
+    const profileId = await searchPage.profileIdOfCard(card);
+    const link = page.locator(`a[href="/players/${profileId}"]`).first();
     await expect(link).toBeVisible();
   });
 
   test("should navigate to the player profile from a result card", async ({ page }) => {
     const searchPage = new SearchPage(page);
     await searchPage.navigate(TEST_PLAYER.alias);
-    await expect(searchPage.playerCard(TEST_PLAYER.profileId)).toBeVisible({ timeout: 30000 });
+    await expect(searchPage.playersResults).toBeVisible({ timeout: 30000 });
 
-    await searchPage.playerCard(TEST_PLAYER.profileId).click();
-    await page.waitForURL(new RegExp(`/players/${TEST_PLAYER.profileId}`));
-    await expect(page.getByTestId("player-name")).toHaveText(TEST_PLAYER.alias);
+    const card = searchPage.playerCards.first();
+    await expect(card).toBeVisible();
+    const profileId = await searchPage.profileIdOfCard(card);
+
+    await card.click();
+    await page.waitForURL(new RegExp(`/players/${profileId}`));
+    // The card truncates long aliases, so assert on the query the API matched rather than on the
+    // exact text of the card.
+    await expect(page.getByTestId("player-name")).toContainText(
+      new RegExp(TEST_PLAYER.alias, "i"),
+    );
   });
 
   test("should show the no-players-found state for a nonsense query", async ({ page }) => {


### PR DESCRIPTION
## Problem

The two `Search Page - player results` tests failed on master ([run 33420514734](https://github.com/cohstats/coh3-stats/actions/runs/33420514734)), on both desktop and mobile:

```
waiting for getByTestId('search-player-card-26631')
```

The player search API answers with a **capped, activity-ordered** list of profiles matching the alias. Profile `26631` still exists and is still called "Thomas", but its last match was a while ago, so it has dropped out of the 58 results the API now returns for `Thomas` — verified against the live endpoint. Any pinned profile id will eventually fall off the same way.

## Fix

Assert on the first returned card instead of a pinned id, keeping the same coverage:

- alias contains the query (the API matches on an alias substring),
- the last-active line is rendered,
- the card links to `/players/<id>`,
- clicking it navigates to that player's page and the name matches the query.

Adds `SearchPage.profileIdOfCard()` to read the profile id back out of the card's test id. `TEST_PLAYER` is untouched — the player-page tests that fetch `26631` directly still pass.

## Verification

Locally against a production build, `e2e/regression/search.spec.ts`:

- `--project=chromium` — 21 passed
- `--project="Mobile Chrome"` — 19 passed, 2 skipped (header search is behind the burger menu on mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved player search coverage by selecting results dynamically instead of relying on a fixed profile.
  * Added validation that returned player aliases contain the search query.
  * Updated navigation checks to verify the selected player’s profile URL and name dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->